### PR TITLE
Feature/tutors update profile

### DIFF
--- a/src/modules/tutor/controllers/tutor.controller.ts
+++ b/src/modules/tutor/controllers/tutor.controller.ts
@@ -25,7 +25,7 @@ export class TutorsController {
   constructor(
     private readonly tutorService: TutorService,
     private readonly userService: UserService,
-  ) {}
+  ) { }
 
   // =====================================================
   // POST /api/v1/tutors
@@ -114,6 +114,17 @@ export class TutorsController {
   }
 
   // =====================================================
+  // GET /api/v1/tutors/profile
+  // VER PERFIL PROPIO (TUTOR)
+  // =====================================================
+  @Get('profile')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR)
+  async getMyProfile(@CurrentUser() user: User) {
+    return this.tutorService.getOwnProfile(user.idUser);
+  }
+
+  // =====================================================
   // GET /api/v1/tutors/:id
   // RF11: Perfil público de tutor
   // =====================================================
@@ -122,4 +133,7 @@ export class TutorsController {
   async getPublicProfile(@Param('id') id: string) {
     return this.tutorService.getPublicProfile(id);
   }
+
+  
 }
+

--- a/src/modules/tutor/controllers/tutor.controller.ts
+++ b/src/modules/tutor/controllers/tutor.controller.ts
@@ -58,6 +58,21 @@ export class TutorsController {
   }
 
   // =====================================================
+  // PATCH /api/v1/tutors/profile/update
+  // RF10: actualizar perfil de tutor
+  // =====================================================
+  @Patch('profile/update')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR)
+  @HttpCode(HttpStatus.OK)
+  async updateProfile(
+    @CurrentUser() user: User,
+    @Body() dto: CompleteTutorProfileDto,
+  ) {
+    return this.tutorService.updateProfile(user.idUser, dto);
+  }
+
+  // =====================================================
   // GET /api/v1/tutors/me/status
   // Estado del perfil del tutor autenticado
   // =====================================================

--- a/src/modules/tutor/services/tutor.service.ts
+++ b/src/modules/tutor/services/tutor.service.ts
@@ -241,6 +241,72 @@ export class TutorService {
   }
 
   // =====================================================
+  // RF12: CONSULTAR PERFIL PROPIO (TUTOR)
+  // =====================================================
+  async getOwnProfile(userId: string): Promise<TutorPublicProfileDto> {
+    // 1. Verificar que sea tutor
+    const isTutor = await this.userService.isTutor(userId);
+    if (!isTutor) {
+      throw new ForbiddenException('Only tutors can access this resource');
+    }
+
+    // 2. Buscar tutor con relaciones
+    const tutor = await this.tutorRepository.findOne({
+      where: { idUser: userId },
+      relations: [
+        'user',
+        'tutorImpartSubjects',
+        'tutorImpartSubjects.subject',
+        'tutorHaveAvailabilities',
+        'tutorHaveAvailabilities.availability',
+      ],
+    });
+
+    if (!tutor) {
+      throw new NotFoundException('Tutor profile not found');
+    }
+
+    // 3. Obtener materias
+    const subjects = await this.subjectService.getSubjectsByTutor(userId);
+
+    // 4. Rating / sesiones (placeholders)
+    const averageRating = 0;
+    const totalRatings = 0;
+    const completedSessions = 0;
+
+    // 5. Modalidades disponibles
+    const availableModalities = [
+      ...new Set(
+        tutor.tutorHaveAvailabilities
+          .filter((ta) => ta.modality !== null)
+          .map((ta) => ta.modality),
+      ),
+    ];
+
+    // 6. Horas
+    const currentWeekHoursUsed = 0;
+    const availableHoursThisWeek =
+      (tutor.limitDisponibility ?? 0) - currentWeekHoursUsed;
+
+    return {
+      id: tutor.idUser,
+      name: tutor.user.name,
+      photo: tutor.urlImage,
+      subjects: subjects.map((s) => ({
+        id: s.idSubject.toString(),
+        name: s.name,
+      })),
+      averageRating,
+      totalRatings,
+      completedSessions,
+      availableModalities,
+      maxWeeklyHours: tutor.limitDisponibility ?? 0,
+      currentWeekHoursUsed,
+      availableHoursThisWeek: Math.max(0, availableHoursThisWeek),
+    };
+  }
+
+  // =====================================================
   // RF14: Visualizar tutores por materia (Código o nombre parcial)
   // =====================================================
   async findTutorsBySubject(subjectTerm: string) {

--- a/src/modules/tutor/services/tutor.service.ts
+++ b/src/modules/tutor/services/tutor.service.ts
@@ -143,6 +143,38 @@ export class TutorService {
   }
 
   // =====================================================
+  // RF10: ACTUALIZAR PERFIL DE TUTOR
+  // =====================================================
+  async updateProfile(userId: string, dto: CompleteTutorProfileDto) {
+
+    // 1. Verificar que sea tutor
+    const isTutor = await this.userService.isTutor(userId);
+    if (!isTutor) {
+      throw new ForbiddenException('Only tutors can update this profile');
+    }
+
+    // 2. Buscar tutor
+    const tutor = await this.tutorRepository.findOne({
+      where: { idUser: userId },
+    });
+    if (!tutor) {
+      throw new NotFoundException('Tutor profile not found');
+    }
+
+    // 3. Actualizar datos del tutor
+    tutor.phone = dto.phone;
+    tutor.urlImage = dto.url_image;
+    tutor.limitDisponibility = dto.max_weekly_hours;
+
+    await this.tutorRepository.save(tutor);
+
+    // 4.  Delegar la asignación de materias al SubjectService
+    await this.subjectService.assignSubjectsToTutor(userId, dto.subject_ids);
+
+    return { message: 'Profile updated successfully' };
+  }
+
+  // =====================================================
   // RF11: CONSULTAR PERFIL PÚBLICO
   // =====================================================
   async getPublicProfile(tutorId: string): Promise<TutorPublicProfileDto> {


### PR DESCRIPTION
# Descripción
Esta rama añade ciertas funcionalidades del tutors module; actualizar información de perfil de tutor, consultar perfil propio de tutor, y activar/desactivar el estado de un tutor (por parte de un ADMIN). Particularmente, se añadieron los endpoints:

PATCH /api/v1/tutors/profile/update :RF10: actualizar perfil de tutor
PATCH /api/v1/tutors/:id/active :Activar / desactivar tutor (ADMIN)
GET /api/v1/tutors/profile :ver perfil propio (TUTOR)

## Tipo de cambio
- [] Bug fix (arreglo de error)
- [x] Nueva funcionalidad
- [ ] Cambio breaking (cambio que requiere ajustes en otras partes)
- [ ] Mejora de rendimiento
- [ ] Refactorización (sin cambios funcionales)
- [ ] Documentación

## ¿Cómo se probó?
- [ ] Tests unitarios
- [x] Tests de integración
- [ ] Pruebas manuales

## Checklist
- [x] Mi código sigue las guías de estilo del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Los tests pasan localmente
- [x] No hay conflictos con la rama principal
