### PR TITLE
feat(tutor-service): added endpoint that returns weekly hours status + unitary test

### DIFF
--- a/src/modules/tutor/controllers/tutor.controller.ts
+++ b/src/modules/tutor/controllers/tutor.controller.ts
@@ -8,6 +8,9 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
+  ParseUUIDPipe,
+  BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { TutorService } from '../services/tutor.service';
 import { UserService } from '../../users/services/users.service';
@@ -123,6 +126,37 @@ export class TutorsController {
   @Roles(UserRole.TUTOR)
   async getMyProfile(@CurrentUser() user: User) {
     return this.tutorService.getOwnProfile(user.idUser);
+  }
+
+  // =====================================================
+  // GET /api/v1/tutors/:id/hours-status
+  // Estado de horas semanales del tutor (TUTOR propio o ADMIN)
+  // =====================================================
+  @Get(':id/hours-status')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR, UserRole.ADMIN)
+  async getTutorHoursStatus(
+    @CurrentUser() user: User,
+    @Param(
+      'id',
+      new ParseUUIDPipe({
+        exceptionFactory: () =>
+          new BadRequestException({
+            errorCode: 'VALIDATION_01',
+            message: 'ID de tutor inválido',
+          }),
+      }),
+    )
+    tutorId: string,
+  ) {
+    if (user.role === UserRole.TUTOR && user.idUser !== tutorId) {
+      throw new ForbiddenException({
+        errorCode: 'PERMISSION_01',
+        message: 'Solo puedes consultar tus propias horas',
+      });
+    }
+
+    return this.tutorService.getTutorHoursStatus(tutorId);
   }
 
   // =====================================================

--- a/src/modules/tutor/services/tutor.service.ts
+++ b/src/modules/tutor/services/tutor.service.ts
@@ -6,7 +6,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository, In, Between } from 'typeorm';
 import { randomBytes } from 'crypto';
 import { Tutor } from '../entities/tutor.entity';
 import { CreateTutorDto } from '../dto/create-tutor.dto';
@@ -17,12 +17,17 @@ import { UserService } from '../../users/services/users.service';
 import { SubjectsService } from '../../subjects/services/subjects.service';
 import { NotificationsService } from '../../notifications/services/notifications.service';
 import { UpdateTutorProfileDto } from '../dto/update-tutor-profile.dto';
+import { Session } from '../../scheduling/entities/session.entity';
+import { SessionStatus } from '../../scheduling/enums/session-status.enum';
+import { startOfWeek, endOfWeek } from 'date-fns';
 
 @Injectable()
 export class TutorService {
   constructor(
     @InjectRepository(Tutor, 'local')
     private readonly tutorRepository: Repository<Tutor>,
+    @InjectRepository(Session, 'local')
+    private readonly sessionRepository: Repository<Session>,
     private readonly userService: UserService,
     private readonly subjectService: SubjectsService,
     private readonly notificationService: NotificationsService,
@@ -499,6 +504,76 @@ export class TutorService {
     }
 
     return tutor.limitDisponibility ?? 8;
+  }
+
+  async getTutorHoursStatus(tutorId: string) {
+    const tutor = await this.tutorRepository.findOne({
+      where: { idUser: tutorId },
+    });
+
+    if (!tutor) {
+      throw new NotFoundException({
+        errorCode: 'RESOURCE_02',
+        message: 'Tutor no encontrado',
+      });
+    }
+
+    const weeklyHoursLimit = tutor.limitDisponibility ?? 8;
+    const { weeklyHoursUsed, weeklyHoursRemaining } =
+      await this.calculateWeeklyHoursStatus(tutorId, weeklyHoursLimit);
+
+    const usedPercentage =
+      weeklyHoursLimit > 0
+        ? Number(((weeklyHoursUsed / weeklyHoursLimit) * 100).toFixed(2))
+        : 0;
+
+    const remainingPercentage =
+      weeklyHoursLimit > 0
+        ? Number(((weeklyHoursRemaining / weeklyHoursLimit) * 100).toFixed(2))
+        : 0;
+
+    return {
+      tutorId,
+      weeklyHoursUsed,
+      weeklyHoursRemaining,
+      usedPercentage,
+      remainingPercentage,
+      consultedAt: new Date().toISOString(),
+    };
+  }
+
+  private async calculateWeeklyHoursStatus(
+    tutorId: string,
+    weeklyHoursLimit: number,
+  ): Promise<{ weeklyHoursUsed: number; weeklyHoursRemaining: number }> {
+    const weekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+    const weekEnd = endOfWeek(new Date(), { weekStartsOn: 1 });
+
+    const weekSessions = await this.sessionRepository.find({
+      where: {
+        idTutor: tutorId,
+        scheduledDate: Between(weekStart, weekEnd),
+        status: In([
+          SessionStatus.SCHEDULED,
+          SessionStatus.PENDING_MODIFICATION,
+        ]),
+      },
+    });
+
+    const weeklyHoursUsed = weekSessions.reduce((sum, session) => {
+      const [startHour, startMin] = session.startTime.split(':').map(Number);
+      const [endHour, endMin] = session.endTime.split(':').map(Number);
+      const duration =
+        (endHour * 60 + endMin - (startHour * 60 + startMin)) / 60;
+      return sum + duration;
+    }, 0);
+
+    const weeklyHoursRemaining = Math.max(0, weeklyHoursLimit - weeklyHoursUsed);
+
+    return {
+      weeklyHoursUsed: Number(weeklyHoursUsed.toFixed(1)),
+      weeklyHoursRemaining: Number(weeklyHoursRemaining.toFixed(1)),
+    };
   }
 
   // =====================================================

--- a/src/modules/tutor/tutor.module.ts
+++ b/src/modules/tutor/tutor.module.ts
@@ -5,6 +5,7 @@ import { Tutor } from './entities/tutor.entity';
 import { User } from '../users/entities/user.entity';
 import { TutorImpartSubject } from '../subjects/entities/tutor-subject.entity';
 import { Subject } from '../subjects/entities/subjects.entity';
+import { Session } from '../scheduling/entities/session.entity';
 import { TutorService } from './services/tutor.service';
 import { TutorsController } from './controllers/tutor.controller';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -14,7 +15,8 @@ import { UsersModule } from '../users/users.module'; // Importar el módulo de U
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      Tutor
+      Tutor,
+      Session,
     ], 'local'), //Especificar la conexión 'local' para usar la configuración de TypeORM del entorno local
     SubjectsModule, //No había importado el módulo de Subjects, lo añado para poder usar el servicio de Subjects dentro del TutorService
     NotificationsModule, // Para EmailService


### PR DESCRIPTION
# Descripción
Se implemento el endpoint GET /api/v1/tutors/:id/hours-status para poder acceder al estado de las horas semanales de disponibilidad de un tutor (horas agendadas, horas restantes, y sus respectivos porcentajes) en el modulo de Tutor.

## Tipo de cambio
- [ ] Bug fix (arreglo de error)
- [x] Nueva funcionalidad
- [ ] Cambio breaking (cambio que requiere ajustes en otras partes)
- [ ] Mejora de rendimiento
- [ ] Refactorización (sin cambios funcionales)
- [ ] Documentación

## ¿Cómo se probó?
- [x] Tests unitarios
- [ ] Tests de integración
- [ ] Pruebas manuales

## Checklist
- [x] Mi código sigue las guías de estilo del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Los tests pasan localmente
- [x] No hay conflictos con la rama principal
