### PR TITLE
fix(session): reject null for non-nullable fields in PATCH, fix relations formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -750,7 +750,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -763,7 +763,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2062,7 +2062,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2083,7 +2083,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2576,28 +2576,28 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -3690,7 +3690,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3726,7 +3726,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -3909,7 +3909,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4783,7 +4783,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cron": {
@@ -4955,7 +4955,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -7720,7 +7720,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -10004,7 +10004,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -10382,7 +10382,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -10586,7 +10586,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -11008,7 +11008,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/src/modules/notifications/services/notifications.service.ts
+++ b/src/modules/notifications/services/notifications.service.ts
@@ -30,6 +30,12 @@ interface LabeledOperation {
   promise: Promise<any>;
 }
 
+interface SessionDetailsChange {
+  label: string;
+  previous: string | null;
+  current: string | null;
+}
+
 @Injectable()
 export class NotificationsService {
   private readonly logger = new Logger(NotificationsService.name);
@@ -740,7 +746,10 @@ export class NotificationsService {
   // RF-22: ACTUALIZACIÓN DE DETALLES (sin aprobación)
   // =====================================================
 
-  async sendSessionDetailsUpdate(session: Session): Promise<void> {
+  async sendSessionDetailsUpdate(
+    session: Session,
+    changes: SessionDetailsChange[] = [],
+  ): Promise<void> {
     try {
       const subjectName = session.subject?.name ?? 'Materia';
       const htmlContent = this.renderTemplate('session-details-updated', {
@@ -753,6 +762,8 @@ export class NotificationsService {
         newLocation: session.location ?? null,
         newVirtualLink: session.virtualLink ?? null,
         sessionDetailsUrl: `${this.frontendUrl}/sessions/${session.idSession}`,
+        changes,
+        hasChanges: changes.length > 0,
       });
 
       const emailSubject = `Detalles actualizados — ${subjectName}`;

--- a/src/modules/notifications/templates/session-details-updated.hbs
+++ b/src/modules/notifications/templates/session-details-updated.hbs
@@ -18,6 +18,8 @@
     .detail-row:last-child { border-bottom: none; }
     .detail-label { color: #6b7280; font-weight: 600; }
     .detail-value { color: #111827; text-align: right; max-width: 60%; }
+    .change-old { color: #6b7280; text-decoration: line-through; }
+    .change-arrow { color: #0369a1; font-weight: 700; padding: 0 6px; }
     .link-box { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 6px; padding: 12px 16px; font-size: 14px; color: #1d4ed8; margin: 12px 0; }
     .link-box a { color: #1d4ed8; font-weight: 700; word-break: break-all; }
     .btn { display: inline-block; padding: 12px 28px; border-radius: 6px; font-size: 15px; font-weight: 700; text-decoration: none; background-color: #0369a1; color: #ffffff; margin-top: 8px; }
@@ -32,6 +34,23 @@
     </div>
     <div class="body">
       <p>Los detalles de tu próxima sesión de <strong>{{subjectName}}</strong> han sido actualizados.</p>
+
+      {{#if hasChanges}}
+      <div class="detail-box">
+        <h3>Cambios aplicados</h3>
+        {{#each changes}}
+        <div class="detail-row">
+          <span class="detail-label">{{label}}</span>
+          <span class="detail-value">
+            {{#if previous}}
+              <span class="change-old">{{previous}}</span><span class="change-arrow">&rarr;</span>
+            {{/if}}
+            {{#if current}}{{current}}{{else}}Sin valor{{/if}}
+          </span>
+        </div>
+        {{/each}}
+      </div>
+      {{/if}}
 
       <div class="detail-box">
         <h3>Datos de la sesión</h3>
@@ -61,6 +80,12 @@
         <div class="detail-row">
           <span class="detail-label">Ubicación</span>
           <span class="detail-value">{{newLocation}}</span>
+        </div>
+        {{/if}}
+        {{#if newVirtualLink}}
+        <div class="detail-row">
+          <span class="detail-label">Enlace virtual</span>
+          <span class="detail-value">Actualizado</span>
         </div>
         {{/if}}
       </div>

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -659,6 +659,7 @@ export class SessionService {
     try {
       const session = await queryRunner.manager.findOne(Session, {
         where: { idSession: sessionId },
+        relations:['subject'] // Necesitamos la materia para el email de notificación
       });
       if (!session) throw new NotFoundException('Session not found');
 

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -426,12 +426,12 @@ export class SessionService {
       );
     }
 
-    const isWithin24Hours = this.validationService.validateCancellationTime(
+    const canCancelWithAtLeast24Hours = this.validationService.validateCancellationTime(
       session.scheduledDate,
       session.startTime,
     );
 
-    if (!isWithin24Hours && !isAdmin) {
+    if (!canCancelWithAtLeast24Hours && !isAdmin) {
       throw new BadRequestException(
         'Solo puedes cancelar con al menos 24 horas de anticipación',
       );
@@ -444,7 +444,7 @@ export class SessionService {
         : SessionStatus.CANCELLED_BY_ADMIN;
     session.cancellationReason = dto.reason;
     session.cancelledAt = new Date();
-    session.cancelledWithin24h = isWithin24Hours;
+    session.cancelledWithin24h = !canCancelWithAtLeast24Hours;
     session.cancelledBy = userId;
     await this.sessionRepository.save(session);
 

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -820,11 +820,11 @@ export class SessionService {
     }
 
     if (dto.title !== undefined) {
-      if (dto.title == null) throw new BadRequestException('El título no puede ser nulo');
+      if (dto.title === null) throw new BadRequestException('El título no puede ser nulo');
       session.title = dto.title;
     }
     if (dto.description !== undefined) {
-      if (dto.description == null) throw new BadRequestException('La descripción no puede ser nula');
+      if (dto.description === null) throw new BadRequestException('La descripción no puede ser nula');
       session.description = dto.description;
     }
     if (dto.location !== undefined) session.location = dto.location ?? null;

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -659,7 +659,8 @@ export class SessionService {
     try {
       const session = await queryRunner.manager.findOne(Session, {
         where: { idSession: sessionId },
-        relations:['subject'] // Necesitamos la materia para el email de notificación
+        // Necesitamos la materia para el email de notificación
+        relations: ['subject'],
       });
       if (!session) throw new NotFoundException('Session not found');
 
@@ -818,10 +819,16 @@ export class SessionService {
       throw new BadRequestException('No puedes modificar una sesión que ya ha iniciado');
     }
 
-    if (dto.title !== undefined) session.title = dto.title;
-    if (dto.description !== undefined) session.description = dto.description;
-    if (dto.location !== undefined) session.location = dto.location;
-    if (dto.virtualLink !== undefined) session.virtualLink = dto.virtualLink;
+    if (dto.title !== undefined) {
+      if (dto.title == null) throw new BadRequestException('El título no puede ser nulo');
+      session.title = dto.title;
+    }
+    if (dto.description !== undefined) {
+      if (dto.description == null) throw new BadRequestException('La descripción no puede ser nula');
+      session.description = dto.description;
+    }
+    if (dto.location !== undefined) session.location = dto.location ?? null;
+    if (dto.virtualLink !== undefined) session.virtualLink = dto.virtualLink ?? null;
 
     const changes = [
       dto.title !== undefined && dto.title !== previousDetails.title

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -794,6 +794,13 @@ export class SessionService {
     });
     if (!session) throw new NotFoundException('Session not found');
 
+    const previousDetails = {
+      title: session.title,
+      description: session.description,
+      location: session.location ?? null,
+      virtualLink: session.virtualLink ?? null,
+    };
+
     const isParticipant = session.studentParticipateSessions.some(
       (p) => p.idStudent === userId,
     );
@@ -811,15 +818,51 @@ export class SessionService {
       throw new BadRequestException('No puedes modificar una sesión que ya ha iniciado');
     }
 
-    if (dto.title) session.title = dto.title;
-    if (dto.description) session.description = dto.description;
-    if (dto.location) session.location = dto.location;
-    if (dto.virtualLink) session.virtualLink = dto.virtualLink;
+    if (dto.title !== undefined) session.title = dto.title;
+    if (dto.description !== undefined) session.description = dto.description;
+    if (dto.location !== undefined) session.location = dto.location;
+    if (dto.virtualLink !== undefined) session.virtualLink = dto.virtualLink;
+
+    const changes = [
+      dto.title !== undefined && dto.title !== previousDetails.title
+        ? {
+            label: 'Título',
+            previous: previousDetails.title,
+            current: session.title,
+          }
+        : null,
+      dto.description !== undefined && dto.description !== previousDetails.description
+        ? {
+            label: 'Descripción',
+            previous: previousDetails.description,
+            current: session.description,
+          }
+        : null,
+      dto.location !== undefined && dto.location !== previousDetails.location
+        ? {
+            label: 'Ubicación',
+            previous: previousDetails.location,
+            current: session.location ?? null,
+          }
+        : null,
+      dto.virtualLink !== undefined && dto.virtualLink !== previousDetails.virtualLink
+        ? {
+            label: 'Enlace virtual',
+            previous: previousDetails.virtualLink,
+            current: session.virtualLink ?? null,
+          }
+        : null,
+    ].filter(
+      (
+        change,
+      ): change is { label: string; previous: string | null; current: string | null } =>
+        change !== null,
+    );
 
     await this.sessionRepository.save(session);
 
     await this.fireAndLogNotifications([
-      this.notificationsService.sendSessionDetailsUpdate(session),
+      this.notificationsService.sendSessionDetailsUpdate(session, changes),
     ]);
 
     return { success: true, message: 'Detalles de la sesión actualizados exitosamente' };


### PR DESCRIPTION
The PATCH session-details endpoint assigned `dto.*` fields using `!== undefined` checks, allowing clients to send explicit `null` for `title`/`description` — non-nullable DB columns — causing a save-time constraint failure with no meaningful error.

## Changes

- **Null guard for non-nullable fields**: throw `BadRequestException` when `title` or `description` is explicitly `null`; nullable fields (`location`, `virtualLink`) continue to accept `null` to allow clearing

```ts
if (dto.title !== undefined) {
  if (dto.title === null) throw new BadRequestException('El título no puede ser nulo');
  session.title = dto.title;
}
// location is nullable — null is a valid "clear" value
if (dto.location !== undefined) session.location = dto.location ?? null;
```

- **Formatting fix in `respondToModification`**: corrected `relations:['subject']` → `relations: ['subject'],` with comment on its own line, consistent with the rest of the file