### PR TITLE
Refactor/CRUD-tutor-availability-by-time-slots

### DIFF
--- a/src/modules/availability/controllers/availability.controller.spec.ts
+++ b/src/modules/availability/controllers/availability.controller.spec.ts
@@ -1,0 +1,158 @@
+import { BadRequestException, ForbiddenException, HttpStatus } from '@nestjs/common';
+import { AvailabilityController } from './availability.controller';
+import { UserRole } from '../../users/entities/user.entity';
+import { SlotAction } from '../enums/slot-action.enum';
+
+describe('AvailabilityController', () => {
+  let controller: AvailabilityController;
+  let subjectsService: any;
+  let tutorService: any;
+  let availabilityService: any;
+
+  beforeEach(() => {
+    subjectsService = {};
+    tutorService = {
+      findByUserId: jest.fn(),
+    };
+    availabilityService = {
+      createSlotsInRange: jest.fn(),
+      updateSlotsInRange: jest.fn(),
+      deleteSlotsInRange: jest.fn(),
+      getTutorAvailability: jest.fn(),
+      getTutorsBySubjectWithAvailability: jest.fn(),
+      createSlot: jest.fn(),
+      updateSlot: jest.fn(),
+      deleteSlot: jest.fn(),
+    };
+
+    controller = new AvailabilityController(
+      subjectsService,
+      tutorService,
+      availabilityService,
+    );
+  });
+
+  describe('createSlotsInRange', () => {
+    it('delegates to availabilityService using authenticated tutor id', async () => {
+      const user = { idUser: 'tutor-1', role: UserRole.TUTOR } as any;
+      const dto = {
+        dayOfWeek: 'MONDAY',
+        startTime: '08:00',
+        endTime: '10:00',
+        modality: 'PRES',
+      } as any;
+      const slots = [{ slotId: 1 }];
+      availabilityService.createSlotsInRange.mockResolvedValue(slots);
+
+      const result = await controller.createSlotsInRange(user, dto);
+
+      expect(availabilityService.createSlotsInRange).toHaveBeenCalledWith(
+        'tutor-1',
+        dto,
+      );
+      expect(result).toEqual({
+        statusCode: HttpStatus.CREATED,
+        message: 'Franjas de disponibilidad creadas exitosamente',
+        slots,
+      });
+    });
+  });
+
+  describe('updateSlotsInRange', () => {
+    it('delegates update to availabilityService using authenticated tutor id', async () => {
+      const user = { idUser: 'tutor-2', role: UserRole.TUTOR } as any;
+      const dto = {
+        dayOfWeek: 'TUESDAY',
+        startTime: '09:00',
+        endTime: '11:00',
+        modality: 'VIRT',
+      } as any;
+      const slots = [{ slotId: 10 }];
+      availabilityService.updateSlotsInRange.mockResolvedValue(slots);
+
+      const result = await controller.updateSlotsInRange(user, dto);
+
+      expect(availabilityService.updateSlotsInRange).toHaveBeenCalledWith(
+        'tutor-2',
+        dto,
+      );
+      expect(result).toEqual({
+        statusCode: HttpStatus.OK,
+        message: 'Franjas de disponibilidad actualizadas exitosamente',
+        slots,
+      });
+    });
+  });
+
+  describe('deleteSlotsInRange', () => {
+    it('delegates delete to availabilityService using authenticated tutor id', async () => {
+      const user = { idUser: 'tutor-3', role: UserRole.TUTOR } as any;
+      const dto = {
+        dayOfWeek: 'WEDNESDAY',
+        startTime: '13:00',
+        endTime: '14:00',
+        modality: 'PRES',
+      } as any;
+      const serviceResult = { deletedSlots: 2 };
+      availabilityService.deleteSlotsInRange.mockResolvedValue(serviceResult);
+
+      const result = await controller.deleteSlotsInRange(user, dto);
+
+      expect(availabilityService.deleteSlotsInRange).toHaveBeenCalledWith(
+        'tutor-3',
+        dto,
+      );
+      expect(result).toEqual({
+        statusCode: HttpStatus.OK,
+        message: 'Franjas de disponibilidad eliminadas exitosamente',
+        ...serviceResult,
+      });
+    });
+  });
+
+  describe('manageSlot', () => {
+    it('keeps existing CREATE branch working', async () => {
+      const user = { idUser: 'tutor-4', role: UserRole.TUTOR } as any;
+      const dto = {
+        action: SlotAction.CREATE,
+        data: {
+          dayOfWeek: 'MONDAY',
+          startTime: '08:00',
+          modality: 'PRES',
+        },
+      } as any;
+      availabilityService.createSlot.mockResolvedValue({ slotId: 1 });
+
+      const result = await controller.manageSlot(user, dto);
+
+      expect(availabilityService.createSlot).toHaveBeenCalledWith('tutor-4', dto.data);
+      expect(result).toEqual({
+        statusCode: HttpStatus.CREATED,
+        message: 'Franja de disponibilidad creada exitosamente',
+        slot: { slotId: 1 },
+      });
+    });
+
+    it('throws when a tutor tries to manage a slot without required data', async () => {
+      const user = { idUser: 'tutor-4', role: UserRole.TUTOR } as any;
+
+      await expect(
+        controller.manageSlot(user, { action: SlotAction.CREATE, data: {} } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('returns tutor availability for the authenticated tutor profile', async () => {
+      const user = { idUser: 'tutor-5', role: UserRole.TUTOR } as any;
+      const tutor = { idUser: 'tutor-5' } as any;
+
+      tutorService.findByUserId.mockResolvedValue(tutor);
+      availabilityService.getTutorAvailability.mockResolvedValue({ tutorId: 'tutor-5' });
+
+      const result = await controller.getMyAvailability(user);
+
+      expect(tutorService.findByUserId).toHaveBeenCalledWith('tutor-5');
+      expect(availabilityService.getTutorAvailability).toHaveBeenCalledWith('tutor-5', {});
+      expect(result).toEqual({ tutorId: 'tutor-5' });
+    });
+  });
+});

--- a/src/modules/availability/controllers/availability.controller.ts
+++ b/src/modules/availability/controllers/availability.controller.ts
@@ -2,6 +2,8 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
+  Delete,
   UseGuards,
   Param,
   Query,
@@ -20,6 +22,7 @@ import { NotFoundException } from '@nestjs/common';
 import { FilterTutorsDto } from '../dto/filter-tutors.dto';
 import { ManageSlotDto } from '../dto/manage-slot.dto';
 import { CreateSlotDto } from '../dto/create-slot.dto';
+import { CreateSlotRangeDto } from '../dto/create-slot-range.dto';
 import { UpdateSlotDto } from '../dto/update-slot.dto';
 import { DeleteSlotDto } from '../dto/delete-slot.dto';
 import { SlotAction } from '../enums/slot-action.enum';
@@ -168,6 +171,69 @@ export class AvailabilityController {
       default:
         throw new BadRequestException('Acción no válida');
     }
+  }
+
+  /**
+   * POST /api/v1/availability/tutor/slots/range
+   * Crea múltiples slots de 30 minutos en un rango horario para el tutor autenticado.
+   */
+  @Post('tutor/slots/range')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR)
+  @HttpCode(HttpStatus.CREATED)
+  async createSlotsInRange(
+    @CurrentUser() user: User,
+    @Body() dto: CreateSlotRangeDto,
+  ) {
+    const slots = await this.availabilityService.createSlotsInRange(user.idUser, dto);
+
+    return {
+      statusCode: HttpStatus.CREATED,
+      message: 'Franjas de disponibilidad creadas exitosamente',
+      slots,
+    };
+  }
+
+  /**
+   * PATCH /api/v1/availability/tutor/slots/range
+   * Actualiza la modalidad de las franjas dentro de un rango para el tutor autenticado.
+   */
+  @Patch('tutor/slots/range')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR)
+  @HttpCode(HttpStatus.OK)
+  async updateSlotsInRange(
+    @CurrentUser() user: User,
+    @Body() dto: CreateSlotRangeDto,
+  ) {
+    const slots = await this.availabilityService.updateSlotsInRange(user.idUser, dto);
+
+    return {
+      statusCode: HttpStatus.OK,
+      message: 'Franjas de disponibilidad actualizadas exitosamente',
+      slots,
+    };
+  }
+
+  /**
+   * DELETE /api/v1/availability/tutor/slots/range
+   * Elimina las franjas dentro de un rango para el tutor autenticado.
+   */
+  @Delete('tutor/slots/range')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR)
+  @HttpCode(HttpStatus.OK)
+  async deleteSlotsInRange(
+    @CurrentUser() user: User,
+    @Body() dto: CreateSlotRangeDto,
+  ) {
+    const result = await this.availabilityService.deleteSlotsInRange(user.idUser, dto);
+
+    return {
+      statusCode: HttpStatus.OK,
+      message: 'Franjas de disponibilidad eliminadas exitosamente',
+      ...result,
+    };
   }
 
   /**

--- a/src/modules/availability/controllers/availability.controller.ts
+++ b/src/modules/availability/controllers/availability.controller.ts
@@ -5,6 +5,7 @@ import {
   Patch,
   Delete,
   UseGuards,
+  UsePipes,
   Param,
   Query,
   Body,
@@ -12,6 +13,7 @@ import {
   HttpStatus,
   BadRequestException,
   ParseUUIDPipe,
+  ValidationPipe,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
@@ -180,6 +182,7 @@ export class AvailabilityController {
   @Post('tutor/slots/range')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.TUTOR)
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }))
   @HttpCode(HttpStatus.CREATED)
   async createSlotsInRange(
     @CurrentUser() user: User,
@@ -201,6 +204,7 @@ export class AvailabilityController {
   @Patch('tutor/slots/range')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.TUTOR)
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }))
   @HttpCode(HttpStatus.OK)
   async updateSlotsInRange(
     @CurrentUser() user: User,
@@ -222,6 +226,7 @@ export class AvailabilityController {
   @Delete('tutor/slots/range')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.TUTOR)
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }))
   @HttpCode(HttpStatus.OK)
   async deleteSlotsInRange(
     @CurrentUser() user: User,

--- a/src/modules/availability/dto/create-slot-range.dto.ts
+++ b/src/modules/availability/dto/create-slot-range.dto.ts
@@ -1,0 +1,34 @@
+import { IsEnum, IsNotEmpty, IsString, Matches } from 'class-validator';
+import { DayOfWeek } from '../enums/day-of-week.enum';
+import { Modality } from '../enums/modality.enum';
+import { IsThirtyMinuteIncrement } from '../validators';
+
+export class CreateSlotRangeDto {
+  @IsNotEmpty({ message: 'El día de la semana es requerido' })
+  @IsEnum(DayOfWeek, { message: 'Día de la semana inválido' })
+  dayOfWeek!: DayOfWeek;
+
+  @IsNotEmpty({ message: 'La hora de inicio es requerida' })
+  @IsString()
+  @Matches(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, {
+    message: 'Formato de hora inválido. Use HH:mm',
+  })
+  @IsThirtyMinuteIncrement({
+    message: 'La hora de inicio debe estar en incrementos de 30 minutos (00 o 30)',
+  })
+  startTime!: string;
+
+  @IsNotEmpty({ message: 'La hora de fin es requerida' })
+  @IsString()
+  @Matches(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, {
+    message: 'Formato de hora inválido. Use HH:mm',
+  })
+  @IsThirtyMinuteIncrement({
+    message: 'La hora de fin debe estar en incrementos de 30 minutos (00 o 30)',
+  })
+  endTime!: string;
+
+  @IsNotEmpty({ message: 'La modalidad es requerida' })
+  @IsEnum(Modality, { message: 'Modalidad inválida (PRES o VIRT)' })
+  modality!: Modality;
+}

--- a/src/modules/availability/dto/index.ts
+++ b/src/modules/availability/dto/index.ts
@@ -3,3 +3,4 @@ export { UpdateSlotDto } from './update-slot.dto';
 export { DeleteSlotDto } from './delete-slot.dto';
 export { ManageSlotDto } from './manage-slot.dto';
 export { FilterTutorsDto } from './filter-tutors.dto';
+export { CreateSlotRangeDto } from './create-slot-range.dto';

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -2,7 +2,6 @@ import { BadRequestException, ConflictException, NotFoundException } from '@nest
 import { AvailabilityService } from './availability.service';
 import { DayOfWeek } from '../enums/day-of-week.enum';
 import { Modality } from '../enums/modality.enum';
-import { SessionStatus } from 'src/modules/scheduling/enums/session-status.enum';
 
 describe('AvailabilityService', () => {
   let service: AvailabilityService;
@@ -14,12 +13,15 @@ describe('AvailabilityService', () => {
   const createQueryBuilderMock = () => ({
     innerJoin: jest.fn().mockReturnThis(),
     innerJoinAndSelect: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
     getCount: jest.fn(),
     getMany: jest.fn(),
     getRawMany: jest.fn(),
+    execute: jest.fn(),
   });
 
   beforeEach(() => {
@@ -172,8 +174,8 @@ describe('AvailabilityService', () => {
 
   describe('updateSlotsInRange', () => {
     it('updates modality for every slot in the range', async () => {
-      const qb = createQueryBuilderMock();
-      qb.getMany.mockResolvedValue([
+      const selectQb = createQueryBuilderMock();
+      selectQb.getMany.mockResolvedValue([
         {
           idTutor: 'tutor-1',
           idAvailability: 21,
@@ -187,8 +189,11 @@ describe('AvailabilityService', () => {
           availability: { startTime: '10:30' },
         },
       ]);
-      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
-      tutorHaveAvailabilityRepository.save.mockResolvedValue({});
+      const updateQb = createQueryBuilderMock();
+      updateQb.execute.mockResolvedValue({ affected: 2 });
+      tutorHaveAvailabilityRepository.createQueryBuilder
+        .mockReturnValueOnce(selectQb)
+        .mockReturnValueOnce(updateQb);
 
       const result = await service.updateSlotsInRange('tutor-1', {
         dayOfWeek: DayOfWeek.TUESDAY,
@@ -197,7 +202,7 @@ describe('AvailabilityService', () => {
         modality: Modality.VIRT,
       });
 
-      expect(tutorHaveAvailabilityRepository.save).toHaveBeenCalledTimes(2);
+      expect(updateQb.execute).toHaveBeenCalledTimes(1);
       expect(result).toEqual([
         {
           slotId: 21,

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -350,5 +350,39 @@ describe('AvailabilityService', () => {
         },
       });
     });
+
+    it('throws VALIDATION_01 when start and end are not aligned to :00/:30 boundaries', async () => {
+      await expect(
+        service.createSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:15',
+          endTime: '09:15',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'VALIDATION_01',
+          message:
+            'La hora de inicio y fin deben estar alineadas a intervalos de 30 minutos',
+        },
+      });
+    });
+
+    it('throws VALIDATION_01 when only endTime is not aligned to :00/:30 boundaries', async () => {
+      await expect(
+        service.updateSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:00',
+          endTime: '09:15',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'VALIDATION_01',
+          message:
+            'La hora de inicio y fin deben estar alineadas a intervalos de 30 minutos',
+        },
+      });
+    });
   });
 });

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -296,7 +296,6 @@ describe('AvailabilityService', () => {
         dayOfWeek: DayOfWeek.WEDNESDAY,
         startTime: '14:00',
         endTime: '15:00',
-        modality: Modality.PRES,
       });
     });
 

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -1,0 +1,334 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { AvailabilityService } from './availability.service';
+import { DayOfWeek } from '../enums/day-of-week.enum';
+import { Modality } from '../enums/modality.enum';
+import { SessionStatus } from 'src/modules/scheduling/enums/session-status.enum';
+
+describe('AvailabilityService', () => {
+  let service: AvailabilityService;
+  let availabilityRepository: any;
+  let tutorHaveAvailabilityRepository: any;
+  let scheduledSessionRepository: any;
+  let sessionRepository: any;
+
+  const createQueryBuilderMock = () => ({
+    innerJoin: jest.fn().mockReturnThis(),
+    innerJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    getCount: jest.fn(),
+    getMany: jest.fn(),
+    getRawMany: jest.fn(),
+  });
+
+  beforeEach(() => {
+    availabilityRepository = {
+      findOne: jest.fn(),
+      create: jest.fn((value) => value),
+      save: jest.fn(),
+    };
+
+    tutorHaveAvailabilityRepository = {
+      findOne: jest.fn(),
+      create: jest.fn((value) => value),
+      save: jest.fn(),
+      remove: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    scheduledSessionRepository = {
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    sessionRepository = {
+      findOne: jest.fn(),
+    };
+
+    service = new AvailabilityService(
+      availabilityRepository,
+      tutorHaveAvailabilityRepository,
+      scheduledSessionRepository,
+      sessionRepository,
+    );
+  });
+
+  describe('createSlotsInRange', () => {
+    it('creates one assignment per 30-minute slot in the range', async () => {
+      const firstQueryBuilder = createQueryBuilderMock();
+      firstQueryBuilder.getCount
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(firstQueryBuilder);
+
+      availabilityRepository.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+      availabilityRepository.save
+        .mockResolvedValueOnce({ idAvailability: 11 })
+        .mockResolvedValueOnce({ idAvailability: 12 });
+      tutorHaveAvailabilityRepository.save.mockResolvedValue({});
+
+      const result = await service.createSlotsInRange('tutor-1', {
+        dayOfWeek: DayOfWeek.MONDAY,
+        startTime: '08:00',
+        endTime: '09:00',
+        modality: Modality.PRES,
+      });
+
+      expect(result).toEqual([
+        {
+          slotId: 11,
+          tutorId: 'tutor-1',
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:00',
+          endTime: '08:30',
+          modality: Modality.PRES,
+          duration: 0.5,
+        },
+        {
+          slotId: 12,
+          tutorId: 'tutor-1',
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:30',
+          endTime: '09:00',
+          modality: Modality.PRES,
+          duration: 0.5,
+        },
+      ]);
+      expect(tutorHaveAvailabilityRepository.save).toHaveBeenCalledTimes(2);
+      expect(availabilityRepository.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws VALIDATION_01 if range is outside allowed hours', async () => {
+      await expect(
+        service.createSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '05:30',
+          endTime: '07:00',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'VALIDATION_01',
+        },
+      });
+    });
+
+    it('throws CONFLICT_01 when the tutor already has overlapping slots', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getCount
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(1);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.createSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:00',
+          endTime: '09:00',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('throws VALIDATION_01 when the daily slot limit is exceeded', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getCount
+        .mockResolvedValueOnce(7)
+        .mockResolvedValueOnce(0);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.createSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:00',
+          endTime: '09:00',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'VALIDATION_01',
+        },
+      });
+    });
+  });
+
+  describe('updateSlotsInRange', () => {
+    it('updates modality for every slot in the range', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 21,
+          modality: Modality.PRES,
+          availability: { startTime: '10:00' },
+        },
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 22,
+          modality: Modality.PRES,
+          availability: { startTime: '10:30' },
+        },
+      ]);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+      tutorHaveAvailabilityRepository.save.mockResolvedValue({});
+
+      const result = await service.updateSlotsInRange('tutor-1', {
+        dayOfWeek: DayOfWeek.TUESDAY,
+        startTime: '10:00',
+        endTime: '11:00',
+        modality: Modality.VIRT,
+      });
+
+      expect(tutorHaveAvailabilityRepository.save).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([
+        {
+          slotId: 21,
+          tutorId: 'tutor-1',
+          dayOfWeek: DayOfWeek.TUESDAY,
+          startTime: '10:00',
+          endTime: '10:30',
+          modality: Modality.VIRT,
+          duration: 0.5,
+        },
+        {
+          slotId: 22,
+          tutorId: 'tutor-1',
+          dayOfWeek: DayOfWeek.TUESDAY,
+          startTime: '10:30',
+          endTime: '11:00',
+          modality: Modality.VIRT,
+          duration: 0.5,
+        },
+      ]);
+    });
+
+    it('throws VALIDATION_01 if update range is outside allowed hours', async () => {
+      await expect(
+        service.updateSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.TUESDAY,
+          startTime: '05:30',
+          endTime: '07:00',
+          modality: Modality.VIRT,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'VALIDATION_01',
+        },
+      });
+    });
+
+    it('throws RESOURCE_02 if no slots are found in the range', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([]);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.updateSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.TUESDAY,
+          startTime: '10:00',
+          endTime: '11:00',
+          modality: Modality.VIRT,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'RESOURCE_02',
+        },
+      });
+    });
+  });
+
+  describe('deleteSlotsInRange', () => {
+    it('removes every slot inside the range and returns deleted count', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 31,
+          modality: Modality.PRES,
+          availability: { startTime: '14:00' },
+        },
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 32,
+          modality: Modality.PRES,
+          availability: { startTime: '14:30' },
+        },
+      ]);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+      tutorHaveAvailabilityRepository.remove.mockResolvedValue({});
+
+      const result = await service.deleteSlotsInRange('tutor-1', {
+        dayOfWeek: DayOfWeek.WEDNESDAY,
+        startTime: '14:00',
+        endTime: '15:00',
+        modality: Modality.PRES,
+      });
+
+      expect(tutorHaveAvailabilityRepository.remove).toHaveBeenCalledWith([
+        expect.objectContaining({ idAvailability: 31 }),
+        expect.objectContaining({ idAvailability: 32 }),
+      ]);
+      expect(result).toEqual({
+        deletedSlots: 2,
+        dayOfWeek: DayOfWeek.WEDNESDAY,
+        startTime: '14:00',
+        endTime: '15:00',
+        modality: Modality.PRES,
+      });
+    });
+
+    it('throws VALIDATION_01 when delete range is not in 30-minute increments', async () => {
+      await expect(
+        service.deleteSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.WEDNESDAY,
+          startTime: '14:15',
+          endTime: '15:00',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'VALIDATION_01',
+        },
+      });
+    });
+
+    it('throws RESOURCE_02 if there are no slots to delete', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([]);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.deleteSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.WEDNESDAY,
+          startTime: '14:00',
+          endTime: '15:00',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'RESOURCE_02',
+        },
+      });
+    });
+  });
+
+  describe('createSlotTimes validation helper behavior via public methods', () => {
+    it('throws VALIDATION_01 when the range is not in 30-minute increments', async () => {
+      await expect(
+        service.createSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:15',
+          endTime: '09:00',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'VALIDATION_01',
+        },
+      });
+    });
+  });
+});

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -296,6 +296,7 @@ describe('AvailabilityService', () => {
         dayOfWeek: DayOfWeek.WEDNESDAY,
         startTime: '14:00',
         endTime: '15:00',
+        modality: Modality.PRES,
       });
     });
 

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -27,6 +27,9 @@ describe('AvailabilityService', () => {
       findOne: jest.fn(),
       create: jest.fn((value) => value),
       save: jest.fn(),
+      manager: {
+        transaction: jest.fn(),
+      },
     };
 
     tutorHaveAvailabilityRepository = {
@@ -51,6 +54,18 @@ describe('AvailabilityService', () => {
       tutorHaveAvailabilityRepository,
       scheduledSessionRepository,
       sessionRepository,
+    );
+
+    availabilityRepository.manager.transaction.mockImplementation(
+      async (callback: (manager: { getRepository: (entity: unknown) => any }) => Promise<unknown>) =>
+        callback({
+          getRepository: (entity: unknown) => {
+            if ((entity as any).name === 'Availability') {
+              return availabilityRepository;
+            }
+            return tutorHaveAvailabilityRepository;
+          },
+        }),
     );
   });
 

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -32,6 +32,7 @@ import { In, MoreThanOrEqual, Repository } from 'typeorm';
 import { Availability } from '../entities/availability.entity';
 import { TutorHaveAvailability } from '../entities/tutor-availability.entity';
 import { CreateSlotDto } from '../dto/create-slot.dto';
+import { CreateSlotRangeDto } from '../dto/create-slot-range.dto';
 import { UpdateSlotDto } from '../dto/update-slot.dto';
 import { DeleteSlotDto } from '../dto/delete-slot.dto';
 import {
@@ -130,6 +131,150 @@ export class AvailabilityService {
       startTime: dto.startTime,
       modality: dto.modality,
       duration: 0.5,
+    };
+  }
+
+  async createSlotsInRange(tutorId: string, dto: CreateSlotRangeDto) {
+    const dayOfWeekNumber = DayOfWeekToNumber[dto.dayOfWeek];
+    const slotTimes = this.buildSlotTimesFromRange(dto.startTime, dto.endTime);
+
+    const existingSlotsInDay = await this.tutorHaveAvailabilityRepository
+      .createQueryBuilder('tha')
+      .innerJoin('tha.availability', 'a')
+      .where('tha.idTutor = :tutorId', { tutorId })
+      .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
+      .getCount();
+
+    if (existingSlotsInDay + slotTimes.length > this.MAX_SLOTS_PER_DAY) {
+      throw new BadRequestException({
+        errorCode: 'VALIDATION_01',
+        message:
+          'Excede el máximo diario de 4 horas. Ya tienes slots registrados para este día.',
+      });
+    }
+
+    const overlappingSlots = await this.tutorHaveAvailabilityRepository
+      .createQueryBuilder('tha')
+      .innerJoin('tha.availability', 'a')
+      .where('tha.idTutor = :tutorId', { tutorId })
+      .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
+      .andWhere('a.startTime IN (:...slotTimes)', { slotTimes })
+      .getCount();
+
+    if (overlappingSlots > 0) {
+      throw new ConflictException({
+        errorCode: 'CONFLICT_01',
+        message: 'El rango contiene horarios que se superponen con disponibilidades existentes',
+      });
+    }
+
+    const createdSlots: Array<{
+      slotId: number;
+      tutorId: string;
+      dayOfWeek: DayOfWeek;
+      startTime: string;
+      endTime: string;
+      modality: Modality;
+      duration: number;
+    }> = [];
+
+    for (const startTime of slotTimes) {
+      let availability = await this.availabilityRepository.findOne({
+        where: { dayOfWeek: dayOfWeekNumber, startTime },
+      });
+
+      if (!availability) {
+        availability = this.availabilityRepository.create({
+          dayOfWeek: dayOfWeekNumber,
+          startTime,
+        });
+        availability = await this.availabilityRepository.save(availability);
+      }
+
+      const assignment = this.tutorHaveAvailabilityRepository.create({
+        idTutor: tutorId,
+        idAvailability: availability.idAvailability,
+        modality: dto.modality,
+      });
+
+      await this.tutorHaveAvailabilityRepository.save(assignment);
+
+      createdSlots.push({
+        slotId: availability.idAvailability,
+        tutorId,
+        dayOfWeek: dto.dayOfWeek,
+        startTime,
+        endTime: this.calculateEndTime(startTime),
+        modality: dto.modality,
+        duration: 0.5,
+      });
+    }
+
+    return createdSlots;
+  }
+
+  async updateSlotsInRange(tutorId: string, dto: CreateSlotRangeDto) {
+    const dayOfWeekNumber = DayOfWeekToNumber[dto.dayOfWeek];
+    const slotTimes = this.buildSlotTimesFromRange(dto.startTime, dto.endTime);
+
+    const slotsToUpdate = await this.tutorHaveAvailabilityRepository
+      .createQueryBuilder('tha')
+      .innerJoinAndSelect('tha.availability', 'a')
+      .where('tha.idTutor = :tutorId', { tutorId })
+      .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
+      .andWhere('a.startTime IN (:...slotTimes)', { slotTimes })
+      .getMany();
+
+    if (slotsToUpdate.length === 0) {
+      throw new NotFoundException({
+        errorCode: 'RESOURCE_02',
+        message: 'No se encontraron franjas de disponibilidad para actualizar',
+      });
+    }
+
+    for (const tutorAvailability of slotsToUpdate) {
+      tutorAvailability.modality = dto.modality;
+      await this.tutorHaveAvailabilityRepository.save(tutorAvailability);
+    }
+
+    return slotsToUpdate.map((slot) => ({
+      slotId: slot.idAvailability,
+      tutorId,
+      dayOfWeek: dto.dayOfWeek,
+      startTime: slot.availability.startTime,
+      endTime: this.calculateEndTime(slot.availability.startTime),
+      modality: dto.modality,
+      duration: 0.5,
+    }));
+  }
+
+  async deleteSlotsInRange(tutorId: string, dto: CreateSlotRangeDto) {
+    const dayOfWeekNumber = DayOfWeekToNumber[dto.dayOfWeek];
+    const slotTimes = this.buildSlotTimesFromRange(dto.startTime, dto.endTime);
+
+    const slotsToDelete = await this.tutorHaveAvailabilityRepository
+      .createQueryBuilder('tha')
+      .innerJoinAndSelect('tha.availability', 'a')
+      .where('tha.idTutor = :tutorId', { tutorId })
+      .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
+      .andWhere('a.startTime IN (:...slotTimes)', { slotTimes })
+      .getMany();
+
+    if (slotsToDelete.length === 0) {
+      throw new NotFoundException({
+        errorCode: 'RESOURCE_02',
+        message: 'No se encontraron franjas de disponibilidad para eliminar',
+      });
+    }
+
+    await this.tutorHaveAvailabilityRepository.remove(slotsToDelete);
+
+    return {
+      deletedSlots: slotsToDelete.length,
+      dayOfWeek: dto.dayOfWeek,
+      startTime: dto.startTime,
+      endTime: dto.endTime,
+      modality: dto.modality,
     };
   }
  
@@ -793,6 +938,53 @@ export class AvailabilityService {
   private calculateEndTime(startTime: string): string {
     const endMinutes = this.timeToMinutes(startTime) + this.SLOT_DURATION_MINUTES;
     return this.minutesToTime(endMinutes);
+  }
+
+  private buildSlotTimesFromRange(startTime: string, endTime: string): string[] {
+    const minAllowedTime = this.timeToMinutes('06:00');
+    const maxAllowedTime = this.timeToMinutes('22:00');
+
+    const startMinutes = this.timeToMinutes(startTime);
+    const endMinutes = this.timeToMinutes(endTime);
+
+    if (startMinutes < minAllowedTime || endMinutes > maxAllowedTime) {
+      throw new BadRequestException({
+        errorCode: 'VALIDATION_01',
+        message: 'El horario debe estar entre 06:00 y 22:00',
+      });
+    }
+
+    if (startMinutes >= endMinutes) {
+      throw new BadRequestException({
+        errorCode: 'VALIDATION_01',
+        message: 'La hora de inicio debe ser menor que la hora de fin',
+      });
+    }
+
+    if ((endMinutes - startMinutes) % this.SLOT_DURATION_MINUTES !== 0) {
+      throw new BadRequestException({
+        errorCode: 'VALIDATION_01',
+        message: 'El rango debe respetar intervalos de 30 minutos',
+      });
+    }
+
+    const slotTimes: string[] = [];
+    for (
+      let current = startMinutes;
+      current < endMinutes;
+      current += this.SLOT_DURATION_MINUTES
+    ) {
+      slotTimes.push(this.minutesToTime(current));
+    }
+
+    if (slotTimes.length === 0) {
+      throw new BadRequestException({
+        errorCode: 'VALIDATION_01',
+        message: 'El rango de horario no contiene slots válidos',
+      });
+    }
+
+    return slotTimes;
   }
  
   private async validateNoOverlap(

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -239,10 +239,15 @@ export class AvailabilityService {
       });
     }
 
-    for (const tutorAvailability of slotsToUpdate) {
-      tutorAvailability.modality = dto.modality;
-      await this.tutorHaveAvailabilityRepository.save(tutorAvailability);
-    }
+    const slotIds = slotsToUpdate.map((slot) => slot.idAvailability);
+
+    await this.tutorHaveAvailabilityRepository
+      .createQueryBuilder()
+      .update(TutorHaveAvailability)
+      .set({ modality: dto.modality })
+      .where('id_tutor = :tutorId', { tutorId })
+      .andWhere('id_availability IN (:...slotIds)', { slotIds })
+      .execute();
 
     return slotsToUpdate.map((slot) => ({
       slotId: slot.idAvailability,

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -138,79 +138,86 @@ export class AvailabilityService {
     const dayOfWeekNumber = DayOfWeekToNumber[dto.dayOfWeek];
     const slotTimes = this.buildSlotTimesFromRange(dto.startTime, dto.endTime);
 
-    const existingSlotsInDay = await this.tutorHaveAvailabilityRepository
-      .createQueryBuilder('tha')
-      .innerJoin('tha.availability', 'a')
-      .where('tha.idTutor = :tutorId', { tutorId })
-      .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
-      .getCount();
+    return this.availabilityRepository.manager.transaction(async (transactionalEntityManager) => {
+      const availabilityRepository =
+        transactionalEntityManager.getRepository(Availability);
+      const tutorHaveAvailabilityRepository =
+        transactionalEntityManager.getRepository(TutorHaveAvailability);
 
-    if (existingSlotsInDay + slotTimes.length > this.MAX_SLOTS_PER_DAY) {
-      throw new BadRequestException({
-        errorCode: 'VALIDATION_01',
-        message:
-          'Excede el máximo diario de 4 horas. Ya tienes slots registrados para este día.',
-      });
-    }
+      const existingSlotsInDay = await tutorHaveAvailabilityRepository
+        .createQueryBuilder('tha')
+        .innerJoin('tha.availability', 'a')
+        .where('tha.idTutor = :tutorId', { tutorId })
+        .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
+        .getCount();
 
-    const overlappingSlots = await this.tutorHaveAvailabilityRepository
-      .createQueryBuilder('tha')
-      .innerJoin('tha.availability', 'a')
-      .where('tha.idTutor = :tutorId', { tutorId })
-      .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
-      .andWhere('a.startTime IN (:...slotTimes)', { slotTimes })
-      .getCount();
-
-    if (overlappingSlots > 0) {
-      throw new ConflictException({
-        errorCode: 'CONFLICT_01',
-        message: 'El rango contiene horarios que se superponen con disponibilidades existentes',
-      });
-    }
-
-    const createdSlots: Array<{
-      slotId: number;
-      tutorId: string;
-      dayOfWeek: DayOfWeek;
-      startTime: string;
-      endTime: string;
-      modality: Modality;
-      duration: number;
-    }> = [];
-
-    for (const startTime of slotTimes) {
-      let availability = await this.availabilityRepository.findOne({
-        where: { dayOfWeek: dayOfWeekNumber, startTime },
-      });
-
-      if (!availability) {
-        availability = this.availabilityRepository.create({
-          dayOfWeek: dayOfWeekNumber,
-          startTime,
+      if (existingSlotsInDay + slotTimes.length > this.MAX_SLOTS_PER_DAY) {
+        throw new BadRequestException({
+          errorCode: 'VALIDATION_01',
+          message:
+            'Excede el máximo diario de 4 horas. Ya tienes slots registrados para este día.',
         });
-        availability = await this.availabilityRepository.save(availability);
       }
 
-      const assignment = this.tutorHaveAvailabilityRepository.create({
-        idTutor: tutorId,
-        idAvailability: availability.idAvailability,
-        modality: dto.modality,
-      });
+      const overlappingSlots = await tutorHaveAvailabilityRepository
+        .createQueryBuilder('tha')
+        .innerJoin('tha.availability', 'a')
+        .where('tha.idTutor = :tutorId', { tutorId })
+        .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
+        .andWhere('a.startTime IN (:...slotTimes)', { slotTimes })
+        .getCount();
 
-      await this.tutorHaveAvailabilityRepository.save(assignment);
+      if (overlappingSlots > 0) {
+        throw new ConflictException({
+          errorCode: 'CONFLICT_01',
+          message: 'El rango contiene horarios que se superponen con disponibilidades existentes',
+        });
+      }
 
-      createdSlots.push({
-        slotId: availability.idAvailability,
-        tutorId,
-        dayOfWeek: dto.dayOfWeek,
-        startTime,
-        endTime: this.calculateEndTime(startTime),
-        modality: dto.modality,
-        duration: 0.5,
-      });
-    }
+      const createdSlots: Array<{
+        slotId: number;
+        tutorId: string;
+        dayOfWeek: DayOfWeek;
+        startTime: string;
+        endTime: string;
+        modality: Modality;
+        duration: number;
+      }> = [];
 
-    return createdSlots;
+      for (const startTime of slotTimes) {
+        let availability = await availabilityRepository.findOne({
+          where: { dayOfWeek: dayOfWeekNumber, startTime },
+        });
+
+        if (!availability) {
+          availability = availabilityRepository.create({
+            dayOfWeek: dayOfWeekNumber,
+            startTime,
+          });
+          availability = await availabilityRepository.save(availability);
+        }
+
+        const assignment = tutorHaveAvailabilityRepository.create({
+          idTutor: tutorId,
+          idAvailability: availability.idAvailability,
+          modality: dto.modality,
+        });
+
+        await tutorHaveAvailabilityRepository.save(assignment);
+
+        createdSlots.push({
+          slotId: availability.idAvailability,
+          tutorId,
+          dayOfWeek: dto.dayOfWeek,
+          startTime,
+          endTime: this.calculateEndTime(startTime),
+          modality: dto.modality,
+          duration: 0.5,
+        });
+      }
+
+      return createdSlots;
+    });
   }
 
   async updateSlotsInRange(tutorId: string, dto: CreateSlotRangeDto) {

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -973,6 +973,16 @@ export class AvailabilityService {
       });
     }
 
+    if (
+      startMinutes % this.SLOT_DURATION_MINUTES !== 0 ||
+      endMinutes % this.SLOT_DURATION_MINUTES !== 0
+    ) {
+      throw new BadRequestException({
+        errorCode: 'VALIDATION_01',
+        message: 'La hora de inicio y fin deben estar alineadas a intervalos de 30 minutos',
+      });
+    }
+
     if ((endMinutes - startMinutes) % this.SLOT_DURATION_MINUTES !== 0) {
       throw new BadRequestException({
         errorCode: 'VALIDATION_01',


### PR DESCRIPTION
# Descripción
Este PR agrega y refactoriza la gestión de franjas de disponibilidad del tutor en el módulo de availability para trabajar con rangos de tiempo en lugar de depender solo de la gestión base por slot.

Incluye tres nuevos endpoints para el tutor autenticado:
- `POST /api/v1/availability/tutor/slots/range`
- `PATCH /api/v1/availability/tutor/slots/range`
- `DELETE /api/v1/availability/tutor/slots/range`

Estos endpoints permiten crear, actualizar y eliminar franjas de disponibilidad usando:
- día de la semana
- hora de inicio
- hora de fin
- modalidad

Además, se incorporan validaciones de negocio para asegurar consistencia en base de datos:
- solo días de lunes a sábado
- horas en incrementos de `:00` o `:30`
- horario entre `06:00` y `22:00`
- validación de solapamiento de franjas
- validación del límite diario de disponibilidad por tutor
- acceso exclusivo para el tutor autenticado

## Tipo de cambio
- [ ] Bug fix (arreglo de error)
- [x] Nueva funcionalidad
- [ ] Cambio breaking (cambio que requiere ajustes en otras partes)
- [ ] Mejora de rendimiento
- [x] Refactorización (sin cambios funcionales)
- [ ] Documentación

## ¿Cómo se probó?
- [x] Tests unitarios
- [ ] Tests de integración
- [x] Pruebas manuales

## Checklist
- [x] Mi código sigue las guías de estilo del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Los tests pasan localmente
- [x] No hay conflictos con la rama principal