### PR TITLE
Refactor/get tutor availability

### DIFF
--- a/src/modules/availability/controllers/availability.controller.spec.ts
+++ b/src/modules/availability/controllers/availability.controller.spec.ts
@@ -190,7 +190,7 @@ describe('AvailabilityController', () => {
       tutorService.findByUserId.mockResolvedValue(tutor);
       availabilityService.getTutorAvailability.mockResolvedValue({ tutorId: 'tutor-5' });
 
-      const result = await controller.getMyAvailability(user);
+      const result = await controller.getMyAvailability(user, {} as any);
 
       expect(tutorService.findByUserId).toHaveBeenCalledWith('tutor-5');
       expect(availabilityService.getTutorAvailability).toHaveBeenCalledWith('tutor-5', {});

--- a/src/modules/availability/controllers/availability.controller.ts
+++ b/src/modules/availability/controllers/availability.controller.ts
@@ -50,6 +50,7 @@ export class AvailabilityController {
   //====================================================
   @Get('tutors/me')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }))
   @Roles(UserRole.TUTOR)
   async getMyAvailability(
     @CurrentUser() user: User,
@@ -74,6 +75,7 @@ export class AvailabilityController {
   // RF-14: Visualizar tutores por materia (Código o Nombre) con su disponibilidad
   //====================================================
   @Get('tutors/subject')
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }))
   async getTutorsBySubject(@Query() filters: FilterTutorsDto) {
   if (!filters.subjectId && !filters.subjectName) {
     throw new BadRequestException('Debe proporcionar subjectId o subjectName');
@@ -121,6 +123,7 @@ export class AvailabilityController {
    */
   @Post('tutor/slots')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }))
   @Roles(UserRole.TUTOR)
   async manageSlot(
     @CurrentUser() user: User,
@@ -187,6 +190,7 @@ export class AvailabilityController {
   //====================================================
   @Patch('tutor/me/limits')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }))
   @Roles(UserRole.TUTOR)
   @HttpCode(HttpStatus.OK)
   async updateMyWeeklyHoursLimit(
@@ -284,6 +288,7 @@ export class AvailabilityController {
    * - modality: PRES/VIRT (filtrar por modalidad)
    */
   @Get('tutors/:tutorId/slots')
+  @UsePipes(new ValidationPipe({ whitelist: true,forbidNonWhitelisted: true, transform: true }))
   async getTutorAvailability(
     @Param('tutorId', ParseUUIDPipe) tutorId: string,
     @Query() query: GetAvailabilityQueryDto,
@@ -302,6 +307,7 @@ export class AvailabilityController {
    * Útil para mostrar un directorio de tutores disponibles
    */
   @Get('tutors/slots')
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }))
   async getAllAvailableTutors(@Query() query: GetAvailabilityQueryDto) {
     return await this.availabilityService.getAllAvailableTutors({
       modality: query.modality,

--- a/src/modules/availability/controllers/availability.controller.ts
+++ b/src/modules/availability/controllers/availability.controller.ts
@@ -52,7 +52,8 @@ export class AvailabilityController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.TUTOR)
   async getMyAvailability(
-    @CurrentUser() user: User
+    @CurrentUser() user: User,
+    @Query() query: GetAvailabilityQueryDto,
 
   ) {
 
@@ -62,7 +63,9 @@ export class AvailabilityController {
     throw new NotFoundException('Tutor profile not found');
   }
 
-    return await this.availabilityService.getTutorAvailability(tutor.idUser, {});
+    return await this.availabilityService.getTutorAvailability(tutor.idUser, {
+      weekStart: query.weekStart, //NUEVO
+    });
   }
 
 
@@ -89,11 +92,12 @@ export class AvailabilityController {
     );
   }
 
-  const { tutors, total } = await this.availabilityService.getTutorsBySubjectWithAvailability(
+  const { tutors, total,weekReference } = await this.availabilityService.getTutorsBySubjectWithAvailability(
     subject.idSubject,
     {
       onlyAvailable: filters.onlyAvailable,
       modality: filters.modality,
+      weekStart: filters.weekStart, //NUEVO
       page: filters.page,
       limit: filters.limit,
     },
@@ -105,6 +109,7 @@ export class AvailabilityController {
       id: subject.idSubject,
       name: subject.name,
     },
+    weekReference, // NUEVO
     ...buildPaginatedResponse(tutors, total, filters.page ?? 1, filters.limit ?? 10),
   };
 }
@@ -287,6 +292,7 @@ export class AvailabilityController {
       onlyAvailable: query.onlyAvailable,
       onlyFuture: query.onlyFuture,
       modality: query.modality,
+      weekStart:     query.weekStart,   // NUEVO
     });
   }
 

--- a/src/modules/availability/dto/GetAvailabilityQueryDto.ts
+++ b/src/modules/availability/dto/GetAvailabilityQueryDto.ts
@@ -1,28 +1,45 @@
 // src/availability/dto/get-availability-query.dto.ts
-import { IsOptional, IsBoolean, IsEnum } from 'class-validator';
-import { Transform } from 'class-transformer';
+import { IsOptional, IsBoolean, IsEnum, IsDateString,IsInt,Min,} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
 import { Modality } from '../enums/modality.enum';
 
 export class GetAvailabilityQueryDto {
   @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
   @IsBoolean()
-  @Transform(({ value }) => {
-    if (value === 'true') return true;
-    if (value === 'false') return false;
-    return value;
-  })
   onlyAvailable?: boolean;
-
+ 
   @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
   @IsBoolean()
-  @Transform(({ value }) => {
-    if (value === 'true') return true;
-    if (value === 'false') return false;
-    return value;
-  })
   onlyFuture?: boolean;
-
+ 
   @IsOptional()
   @IsEnum(Modality)
   modality?: Modality;
+ 
+  /**
+   * Lunes de la semana a consultar, formato YYYY-MM-DD.
+   * Si no se pasa, se usa el lunes de la semana actual.
+   *
+   * El front puede usar esto para navegar semanas:
+   *   Esta semana:     sin parámetro (o el lunes actual)
+   *   Próxima semana:  ?weekStart=2025-04-21
+   *   En dos semanas:  ?weekStart=2025-04-28
+   */
+  @IsOptional()
+  @IsDateString({}, { message: 'weekStart debe ser una fecha válida en formato YYYY-MM-DD' })
+  weekStart?: string;
+ 
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+ 
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
 }

--- a/src/modules/availability/dto/filter-tutors.dto.ts
+++ b/src/modules/availability/dto/filter-tutors.dto.ts
@@ -23,4 +23,8 @@ export class FilterTutorsDto extends PaginationDto{
   @IsBoolean()
   @Transform(({ value }) => value === 'true' || value === true)
   onlyAvailable?: boolean;
+
+  @IsOptional()
+  @IsString()
+  weekStart?: string; // Agregado para filtrar por semana específica
 }

--- a/src/modules/availability/dto/filter-tutors.dto.ts
+++ b/src/modules/availability/dto/filter-tutors.dto.ts
@@ -1,5 +1,5 @@
 // src/availability/dto/filter-tutors.dto.ts
-import { IsOptional, IsString, IsNumber, IsEnum, IsBoolean } from 'class-validator';
+import { IsOptional, IsString, IsNumber, IsEnum, IsBoolean, IsDateString } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { Modality } from '../enums/modality.enum';
 import { UUID } from 'typeorm/driver/mongodb/bson.typings.js';
@@ -25,6 +25,6 @@ export class FilterTutorsDto extends PaginationDto{
   onlyAvailable?: boolean;
 
   @IsOptional()
-  @IsString()
+  @IsDateString()
   weekStart?: string; // Agregado para filtrar por semana específica
 }

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -48,11 +48,12 @@ import { Session } from 'src/modules/scheduling/entities/session.entity';
 export interface AvailabilitySlot {
   slotId: string;
   dayOfWeek: DayOfWeek;
+  dayOfWeekNumber: number;   // 0=Lun…5=Sáb, útil para el front si necesita ordenar
   startTime: string;
   endTime: string;
   modality: Modality;
   duration: number;
-  isAvailable: boolean;
+  isAvailable: boolean; // true si no hay sesión activa en la semana de referencia
 }
  
 export interface TutorAvailabilityPublic {
@@ -61,6 +62,7 @@ export interface TutorAvailabilityPublic {
   totalSlots: number;
   availableSlots: AvailabilitySlot[];
   groupedByDay: Record<DayOfWeek, AvailabilitySlot[]>;
+  weekReference: string //Lunes de la semana consultada, para que el front sepa qué semana es
 }
  
 // ─────────────────────────────────────────────────────────────────────────────
@@ -399,6 +401,7 @@ export class AvailabilityService {
       onlyAvailable?: boolean;
       onlyFuture?: boolean;
       modality?: Modality;
+      weekStart?:string //'YYYY-MM-DD' (lunes de la semana a consultar
     },
   ): Promise<TutorAvailabilityPublic> {
     const tutorAvailabilities = await this.tutorHaveAvailabilityRepository.find({
@@ -411,7 +414,8 @@ export class AvailabilityService {
     }
  
     // Obtener sesiones activas del tutor con su duración real
-    const occupiedRanges = await this.buildOccupiedRangesForTutor(tutorId);
+    const{weekStartStr, weekEndStr} = this.resolveWeekRange(options?.weekStart);
+    const occupiedRanges = await this.buildOccupiedRangesForTutor(tutorId,weekStartStr,weekEndStr);
  
     let slots: AvailabilitySlot[] = tutorAvailabilities.map((ta) => {
       const startTime = ta.availability.startTime;
@@ -422,6 +426,7 @@ export class AvailabilityService {
       return {
         slotId:      ta.idAvailability.toString(),
         dayOfWeek:   NumberToDayOfWeek[ta.availability.dayOfWeek],
+        dayOfWeekNumber: ta.availability.dayOfWeek,
         startTime,
         endTime,
         modality:    ta.modality,
@@ -438,15 +443,22 @@ export class AvailabilityService {
     return {
       tutorId,
       tutorName:      tutorAvailabilities[0].tutor.user.name,
+      weekReference:     weekStartStr,
       totalSlots:     slots.length,
       availableSlots: slots.filter((s) => s.isAvailable),
       groupedByDay,
     };
   }
  
+  /**
+   * 
+   * @param options Modality y/o onlyAvailable para filtrar los tutores, y weekStart para que el front sepa a qué semana corresponde la disponibilidad (lunes de la semana en formato 'YYYY-MM-DD') 
+   * @return Lista de tutores con disponibilidad, filtrados por modalidad y/o solo disponibles, sin importar la materia. Útil para el buscador general de tutores.
+   */
   async getAllAvailableTutors(options?: {
     modality?: Modality;
     onlyAvailable?: boolean;
+    weekStart?:string //'YYYY-MM-DD' (lunes de la semana a consultar)
   }): Promise<
     Array<{
       tutorId: string;
@@ -470,19 +482,24 @@ export class AvailabilityService {
       { tutorId: string; tutorName: string; slots: TutorHaveAvailability[] }
     >();
  
-    tutorsWithAvailability.forEach((ta) => {
+    for(const ta of tutorsWithAvailability) {
       if (!tutorMap.has(ta.idTutor)) {
         tutorMap.set(ta.idTutor, { tutorId: ta.idTutor, tutorName: ta.tutor.user.name, slots: [] });
       }
       tutorMap.get(ta.idTutor)!.slots.push(ta);
-    });
+    }
  
     // Obtener rangos ocupados para todos los tutores de una vez
     const allTutorIds = Array.from(tutorMap.keys());
-    const occupiedRangesByTutor = await this.buildOccupiedRangesForTutors(allTutorIds);
+    const { weekStartStr, weekEndStr } = this.resolveWeekRange(options?.weekStart);
+    const occupiedRangesByTutor = await this.buildOccupiedRangesForTutors(
+      allTutorIds,
+      weekStartStr,
+      weekEndStr,
+    );
  
     const result = Array.from(tutorMap.values()).map((tutor) => {
-      const occupiedRanges = occupiedRangesByTutor.get(tutor.tutorId) ?? [];
+      const occupied = occupiedRangesByTutor.get(tutor.tutorId) ?? [];
  
       let slots = tutor.slots;
       if (options?.modality) {
@@ -491,7 +508,7 @@ export class AvailabilityService {
  
       const totalSlots = slots.length;
       const availableCount = slots.filter(
-        (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, occupiedRanges),
+        (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, occupied),
       ).length;
  
       if (options?.onlyAvailable && availableCount === 0) return null;
@@ -511,6 +528,7 @@ export class AvailabilityService {
       modality?: Modality;
       page?: number;
       limit?: number;
+      weekStart?:string //'YYYY-MM-DD' (lunes de la semana a consultar)
     },
   ): Promise<{
     tutors: {
@@ -522,11 +540,13 @@ export class AvailabilityService {
       availability: TutorAvailabilityPublic;
     }[];
     total: number;
+    weekReference: string;
   }> {
     const page   = options?.page  ?? 1;
     const limit  = options?.limit ?? 10;
     const offset = (page - 1) * limit;
- 
+    const {weekStartStr, weekEndStr} = this.resolveWeekRange(options?.weekStart);
+
     // 1. IDs elegibles
     const eligibleTutorsQuery = this.tutorHaveAvailabilityRepository
       .createQueryBuilder('tha')
@@ -541,13 +561,17 @@ export class AvailabilityService {
       eligibleTutorsQuery.andWhere('tha.modality = :modality', { modality: options.modality });
     }
  
-    const allEligibleTutors = await eligibleTutorsQuery.getRawMany<{ tutorId: string }>();
-    if (allEligibleTutors.length === 0) return { tutors: [], total: 0 };
+    const allEligible = await eligibleTutorsQuery.getRawMany<{ tutorId: string }>();
+    if (allEligible.length === 0) return { tutors: [], total: 0, weekReference: weekStartStr };
  
-    const allEligibleIds = allEligibleTutors.map((r) => r.tutorId);
+    const allEligibleIds = allEligible.map((r) => r.tutorId);
  
-    // 2. Calcular rangos ocupados para todos los elegibles
-    const occupiedRangesByTutor = await this.buildOccupiedRangesForTutors(allEligibleIds);
+    // 2. Calcular rangos ocupados para la semana dada de los tutores elegibles
+    const occupiedRangesByTutor = await this.buildOccupiedRangesForTutors(
+      allEligibleIds,
+      weekStartStr,
+      weekEndStr
+    );
  
     // 3. Cargar todos sus slots para poder filtrar por disponibilidad real
     const allSlotsForEligible = await this.tutorHaveAvailabilityRepository
@@ -575,12 +599,12 @@ export class AvailabilityService {
         return hasAvailable;
       });
  
-      if (finalIds.length === 0) return { tutors: [], total: 0 };
+      if (finalIds.length === 0) return { tutors: [], total: 0, weekReference: weekStartStr };
     }
  
     const total    = finalIds.length;
     const pagedIds = finalIds.slice(offset, offset + limit);
-    if (pagedIds.length === 0) return { tutors: [], total };
+    if (pagedIds.length === 0) return { tutors: [], total, weekReference: weekStartStr };
  
     // 5. Cargar datos completos para la página
     const slotsQuery = this.tutorHaveAvailabilityRepository
@@ -601,25 +625,25 @@ export class AvailabilityService {
       { tutorId: string; tutorName: string; slots: TutorHaveAvailability[] }
     >();
  
-    slots.forEach((slot) => {
+    for(const slot of slots) {
       if (!tutorMap.has(slot.idTutor)) {
         tutorMap.set(slot.idTutor, { tutorId: slot.idTutor, tutorName: slot.tutor.user.name, slots: [] });
       }
       tutorMap.get(slot.idTutor)!.slots.push(slot);
-    });
+    };
  
-    // 6. Construir respuesta usando la nueva lógica de bloques
+    // 6. Construir respuesta usando la nueva lógica de bloques y isAvailable por semana
     const tutors = pagedIds
       .filter((id) => tutorMap.has(id))
       .map((id) => {
         const tutor        = tutorMap.get(id)!;
         const occupied     = occupiedRangesByTutor.get(id) ?? [];
-        const tutorSlots   = tutor.slots;
+        //const tutorSlots   = tutor.slots;
  
         const availableSlotsArray: AvailabilitySlot[] = [];
         const groupedByDay = {} as Record<DayOfWeek, AvailabilitySlot[]>;
  
-        tutorSlots.forEach((slot) => {
+        for (const slot of tutor.slots) {
           const dayOfWeek  = NumberToDayOfWeek[slot.availability.dayOfWeek];
           const startTime  = slot.availability.startTime;
           const endTime    = this.calculateEndTime(startTime);
@@ -628,6 +652,7 @@ export class AvailabilityService {
           const slotData: AvailabilitySlot = {
             slotId:      slot.idAvailability.toString(),
             dayOfWeek,
+            dayOfWeekNumber: slot.availability.dayOfWeek,
             startTime,
             endTime,
             modality:    slot.modality,
@@ -638,31 +663,33 @@ export class AvailabilityService {
           if (!isOccupied) availableSlotsArray.push(slotData);
           if (!groupedByDay[dayOfWeek]) groupedByDay[dayOfWeek] = [];
           groupedByDay[dayOfWeek].push(slotData);
-        });
+        };
+
+        //Ordenar por hora dentro de cada día
  
         Object.keys(groupedByDay).forEach((day) => {
           groupedByDay[day as DayOfWeek].sort((a, b) => a.startTime.localeCompare(b.startTime));
         });
  
-        const modalities = [...new Set(tutorSlots.map((s) => s.modality))] as Modality[];
+        const modalities = [...new Set(tutor.slots.map((s) => s.modality))] as Modality[];
  
         return {
           tutorId:        tutor.tutorId,
           tutorName:      tutor.tutorName,
-          totalSlots:     tutorSlots.length,
+          totalSlots:     tutor.slots.length,
           availableSlots: availableSlotsArray.length,
           modalities,
           availability: {
             tutorId:        tutor.tutorId,
             tutorName:      tutor.tutorName,
-            totalSlots:     tutorSlots.length,
+            totalSlots:     tutor.slots.length,
             availableSlots: availableSlotsArray,
             groupedByDay,
           } as TutorAvailabilityPublic,
         };
       });
  
-    return { tutors, total };
+    return { tutors, total, weekReference: weekStartStr };
   }
  
   // =====================================================
@@ -826,12 +853,13 @@ export class AvailabilityService {
   /**
    * Construye los rangos de minutos ocupados para un solo tutor.
    * Usado en getTutorAvailability() donde solo hay un tutor.
-   */
+   
   private async buildOccupiedRangesForTutor(tutorId: string): Promise<OccupiedRange[]> {
     const map = await this.buildOccupiedRangesForTutors([tutorId]);
     return map.get(tutorId) ?? [];
   }
- 
+ */
+
   /**
    * Construye los rangos de minutos ocupados para múltiples tutores en una sola
    * ronda de consultas. Devuelve Map<tutorId, OccupiedRange[]>.
@@ -842,7 +870,7 @@ export class AvailabilityService {
    *
    * El cálculo usa Session.startTime y Session.endTime (la duración real agendada),
    * no el slot de 30 min de Availability. Así captura correctamente bloques de 1h o 1.5h.
-   */
+   
   private async buildOccupiedRangesForTutors(
     tutorIds: string[],
   ): Promise<Map<string, OccupiedRange[]>> {
@@ -880,6 +908,7 @@ export class AvailabilityService {
  
     return result;
   }
+  */
  
   /**
    * Determina si un slot (definido por su startTime) queda dentro de algún
@@ -914,6 +943,103 @@ export class AvailabilityService {
  
     return this.timeToMinutes(session.endTime) - this.timeToMinutes(session.startTime);
   }
+
+
+  // =====================================================
+  // HELPERS PRIVADOS — LÓGICA DE SEMANA
+  // =====================================================
+ 
+  /**
+   * Resuelve el rango lunes–domingo para una semana dada.
+   * Si weekStart no se pasa, usa el lunes de la semana actual.
+   * Devuelve strings 'YYYY-MM-DD' para usarlos directamente en queries.
+   */
+  private resolveWeekRange(weekStart?: string): {
+    weekStartStr: string;
+    weekEndStr: string;
+  } {
+    let monday: Date;
+ 
+    if (weekStart) {
+      // Construir en UTC para evitar desfase de zona horaria
+      const [y, m, d] = weekStart.split('-').map(Number);
+      monday = new Date(Date.UTC(y, m - 1, d));
+    } else {
+      // Lunes de la semana actual en UTC
+      const now = new Date();
+      const dayOfWeek = now.getUTCDay(); // 0=Dom, 1=Lun, ..., 6=Sáb
+      const daysToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      monday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + daysToMonday));
+    }
+ 
+    // Domingo = lunes + 6 días
+    const sunday = new Date(monday);
+    sunday.setUTCDate(sunday.getUTCDate() + 6);
+ 
+    return {
+      weekStartStr: monday.toISOString().split('T')[0],
+      weekEndStr:   sunday.toISOString().split('T')[0],
+    };
+  }
+ 
+  /**
+   * Calcula los rangos de minutos ocupados para múltiples tutores
+   * dentro de una semana específica (lunes a domingo).
+   *
+   * Un slot queda marcado como ocupado si tiene una sesión activa
+   * en CUALQUIER fecha dentro de esa semana. Esto es correcto porque
+   * un slot (día+hora) solo puede tener una sesión por semana —
+   * si el lunes de esta semana está ocupado, ese slot del lunes
+   * no está disponible esta semana, pero sí la siguiente.
+   */
+  private async buildOccupiedRangesForTutors(
+    tutorIds: string[],
+    weekStartStr: string,
+    weekEndStr: string,
+  ): Promise<Map<string, OccupiedRange[]>> {
+    if (!tutorIds.length) return new Map();
+ 
+    const activeSessions = await this.scheduledSessionRepository
+      .createQueryBuilder('ss')
+      .innerJoinAndSelect('ss.session', 'session')
+      .innerJoinAndSelect('ss.availability', 'availability')
+      .where('ss.id_tutor IN (:...tutorIds)', { tutorIds })
+      // Sesiones dentro de la semana de referencia
+      .andWhere('ss.scheduled_date BETWEEN :weekStart AND :weekEnd', {
+        weekStart: weekStartStr,
+        weekEnd:   weekEndStr,
+      })
+      .andWhere('session.status IN (:...activeStatuses)', {
+        activeStatuses: [
+          SessionStatus.SCHEDULED,
+          SessionStatus.PENDING_MODIFICATION,
+          SessionStatus.PENDING_TUTOR_CONFIRMATION,
+        ],
+      })
+      .getMany();
+ 
+    const result = new Map<string, OccupiedRange[]>();
+ 
+    for (const ss of activeSessions) {
+      if (!result.has(ss.idTutor)) result.set(ss.idTutor, []);
+      result.get(ss.idTutor)!.push({
+        startMinutes: this.timeToMinutes(ss.session.startTime),
+        endMinutes:   this.timeToMinutes(ss.session.endTime),
+      });
+    }
+ 
+    return result;
+  }
+ 
+  private async buildOccupiedRangesForTutor(
+    tutorId: string,
+    weekStartStr: string,
+    weekEndStr: string,
+  ): Promise<OccupiedRange[]> {
+    const map = await this.buildOccupiedRangesForTutors([tutorId], weekStartStr, weekEndStr);
+    return map.get(tutorId) ?? [];
+  }
+
  
   // =====================================================
   // HELPERS PRIVADOS — UTILIDADES

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -69,7 +69,6 @@ export interface TutorAvailabilityPublic {
 // Rango de tiempo ocupado (en minutos desde medianoche, dentro de un día)
 // ─────────────────────────────────────────────────────────────────────────────
 interface OccupiedRange {
-  dayOfWeek: number;
   startMinutes: number;
   endMinutes: number;
 }
@@ -422,7 +421,7 @@ export class AvailabilityService {
       const startTime = ta.availability.startTime;
       const endTime   = this.calculateEndTime(startTime);
  
-      const isOccupied = this.isSlotOccupiedByBlock(startTime, ta.availability.dayOfWeek, occupiedRanges);
+      const isOccupied = this.isSlotOccupiedByBlock(startTime, occupiedRanges);
  
       return {
         slotId:      ta.idAvailability.toString(),
@@ -509,7 +508,7 @@ export class AvailabilityService {
  
       const totalSlots = slots.length;
       const availableCount = slots.filter(
-        (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, s.availability.dayOfWeek, occupied),
+        (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, occupied),
       ).length;
  
       if (options?.onlyAvailable && availableCount === 0) return null;
@@ -595,7 +594,7 @@ export class AvailabilityService {
         const slots        = slotsByTutor.get(id) ?? [];
         const occupied     = occupiedRangesByTutor.get(id) ?? [];
         const hasAvailable = slots.some(
-          (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, s.availability.dayOfWeek, occupied),
+          (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, occupied),
         );
         return hasAvailable;
       });
@@ -648,7 +647,7 @@ export class AvailabilityService {
           const dayOfWeek  = NumberToDayOfWeek[slot.availability.dayOfWeek];
           const startTime  = slot.availability.startTime;
           const endTime    = this.calculateEndTime(startTime);
-          const isOccupied = this.isSlotOccupiedByBlock(startTime, slot.availability.dayOfWeek, occupied);
+          const isOccupied = this.isSlotOccupiedByBlock(startTime, occupied);
  
           const slotData: AvailabilitySlot = {
             slotId:      slot.idAvailability.toString(),
@@ -686,7 +685,8 @@ export class AvailabilityService {
             totalSlots:     tutor.slots.length,
             availableSlots: availableSlotsArray,
             groupedByDay,
-          } as TutorAvailabilityPublic,
+            weekReference: weekStartStr,
+          },
         };
       });
  
@@ -852,66 +852,6 @@ export class AvailabilityService {
   // =====================================================
  
   /**
-   * Construye los rangos de minutos ocupados para un solo tutor.
-   * Usado en getTutorAvailability() donde solo hay un tutor.
-   
-  private async buildOccupiedRangesForTutor(tutorId: string): Promise<OccupiedRange[]> {
-    const map = await this.buildOccupiedRangesForTutors([tutorId]);
-    return map.get(tutorId) ?? [];
-  }
- */
-
-  /**
-   * Construye los rangos de minutos ocupados para múltiples tutores en una sola
-   * ronda de consultas. Devuelve Map<tutorId, OccupiedRange[]>.
-   *
-   * Para cada sesión activa:
-   *   - startMinutes = hora de inicio del slot seleccionado
-   *   - endMinutes   = startMinutes + duración real de la sesión (Session.endTime - startTime)
-   *
-   * El cálculo usa Session.startTime y Session.endTime (la duración real agendada),
-   * no el slot de 30 min de Availability. Así captura correctamente bloques de 1h o 1.5h.
-   
-  private async buildOccupiedRangesForTutors(
-    tutorIds: string[],
-  ): Promise<Map<string, OccupiedRange[]>> {
-    if (!tutorIds.length) return new Map();
- 
-    // Traer sesiones activas con su slot de inicio y los tiempos de la sesión
-    const activeSessions = await this.scheduledSessionRepository
-      .createQueryBuilder('ss')
-      .innerJoinAndSelect('ss.session', 'session')
-      .innerJoinAndSelect('ss.availability', 'availability')
-      .where('ss.id_tutor IN (:...tutorIds)', { tutorIds })
-      .andWhere('session.status IN (:...activeStatuses)', {
-        activeStatuses: [
-          SessionStatus.SCHEDULED,
-          SessionStatus.PENDING_MODIFICATION,
-          SessionStatus.PENDING_TUTOR_CONFIRMATION,
-        ],
-      })
-      .getMany();
- 
-    const result = new Map<string, OccupiedRange[]>();
- 
-    for (const ss of activeSessions) {
-      if (!result.has(ss.idTutor)) result.set(ss.idTutor, []);
- 
-      // La duración real de la sesión viene de Session.startTime y Session.endTime
-      const sessionStartMinutes = this.timeToMinutes(ss.session.startTime);
-      const sessionEndMinutes   = this.timeToMinutes(ss.session.endTime);
- 
-      result.get(ss.idTutor)!.push({
-        startMinutes: sessionStartMinutes,
-        endMinutes:   sessionEndMinutes,
-      });
-    }
- 
-    return result;
-  }
-  */
- 
-  /**
    * Determina si un slot (definido por su startTime) queda dentro de algún
    * rango ocupado. Un slot de 30 min ocupa [slotStart, slotStart + 30).
    * Hay solapamiento si el slot empieza antes de que el bloque termine
@@ -919,17 +859,13 @@ export class AvailabilityService {
    */
   private isSlotOccupiedByBlock(
     slotStartTime: string,
-    slotDayOfWeek: number,
     occupiedRanges: OccupiedRange[],
   ): boolean {
     const slotStart = this.timeToMinutes(slotStartTime);
     const slotEnd   = slotStart + this.SLOT_DURATION_MINUTES;
-
+ 
     return occupiedRanges.some(
-      (range) =>
-        range.dayOfWeek === slotDayOfWeek &&
-        slotStart < range.endMinutes &&
-        slotEnd > range.startMinutes,
+      (range) => slotStart < range.endMinutes && slotEnd > range.startMinutes,
     );
   }
  
@@ -967,8 +903,41 @@ export class AvailabilityService {
  
     if (weekStart) {
       // Construir en UTC para evitar desfase de zona horaria
-      const [y, m, d] = weekStart.split('-').map(Number);
+      const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(weekStart);
+      if (!match) {
+        throw new BadRequestException(
+          'weekStart must have format YYYY-MM-DD',
+        );
+      }
+ 
+      const y = Number(match[1]);
+      const m = Number(match[2]);
+      const d = Number(match[3]);
+ 
+      if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
+        throw new BadRequestException(
+          'weekStart must be a valid date in format YYYY-MM-DD',
+        );
+      }
+ 
+      // Construir en UTC para evitar desfase de zona horaria
       monday = new Date(Date.UTC(y, m - 1, d));
+ 
+      const isValidDate =
+        !Number.isNaN(monday.getTime()) &&
+        monday.getUTCFullYear() === y &&
+        monday.getUTCMonth() === m - 1 &&
+        monday.getUTCDate() === d;
+ 
+      if (!isValidDate) {
+        throw new BadRequestException(
+          'weekStart must be a valid date in format YYYY-MM-DD',
+        );
+      }
+ 
+      if (monday.getUTCDay() !== 1) {
+        throw new BadRequestException('weekStart must be a Monday');
+      }
     } else {
       // Lunes de la semana actual en UTC
       const now = new Date();
@@ -1028,15 +997,14 @@ export class AvailabilityService {
     for (const ss of activeSessions) {
       if (!result.has(ss.idTutor)) result.set(ss.idTutor, []);
       result.get(ss.idTutor)!.push({
-        dayOfWeek:    ss.availability.dayOfWeek,
         startMinutes: this.timeToMinutes(ss.session.startTime),
         endMinutes:   this.timeToMinutes(ss.session.endTime),
       });
     }
-
+ 
     return result;
   }
-
+ 
   private async buildOccupiedRangesForTutor(
     tutorId: string,
     weekStartStr: string,

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -69,6 +69,7 @@ export interface TutorAvailabilityPublic {
 // Rango de tiempo ocupado (en minutos desde medianoche, dentro de un día)
 // ─────────────────────────────────────────────────────────────────────────────
 interface OccupiedRange {
+  dayOfWeek: number;
   startMinutes: number;
   endMinutes: number;
 }
@@ -421,7 +422,7 @@ export class AvailabilityService {
       const startTime = ta.availability.startTime;
       const endTime   = this.calculateEndTime(startTime);
  
-      const isOccupied = this.isSlotOccupiedByBlock(startTime, occupiedRanges);
+      const isOccupied = this.isSlotOccupiedByBlock(startTime, ta.availability.dayOfWeek, occupiedRanges);
  
       return {
         slotId:      ta.idAvailability.toString(),
@@ -508,7 +509,7 @@ export class AvailabilityService {
  
       const totalSlots = slots.length;
       const availableCount = slots.filter(
-        (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, occupied),
+        (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, s.availability.dayOfWeek, occupied),
       ).length;
  
       if (options?.onlyAvailable && availableCount === 0) return null;
@@ -594,7 +595,7 @@ export class AvailabilityService {
         const slots        = slotsByTutor.get(id) ?? [];
         const occupied     = occupiedRangesByTutor.get(id) ?? [];
         const hasAvailable = slots.some(
-          (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, occupied),
+          (s) => !this.isSlotOccupiedByBlock(s.availability.startTime, s.availability.dayOfWeek, occupied),
         );
         return hasAvailable;
       });
@@ -647,7 +648,7 @@ export class AvailabilityService {
           const dayOfWeek  = NumberToDayOfWeek[slot.availability.dayOfWeek];
           const startTime  = slot.availability.startTime;
           const endTime    = this.calculateEndTime(startTime);
-          const isOccupied = this.isSlotOccupiedByBlock(startTime, occupied);
+          const isOccupied = this.isSlotOccupiedByBlock(startTime, slot.availability.dayOfWeek, occupied);
  
           const slotData: AvailabilitySlot = {
             slotId:      slot.idAvailability.toString(),
@@ -918,13 +919,17 @@ export class AvailabilityService {
    */
   private isSlotOccupiedByBlock(
     slotStartTime: string,
+    slotDayOfWeek: number,
     occupiedRanges: OccupiedRange[],
   ): boolean {
     const slotStart = this.timeToMinutes(slotStartTime);
     const slotEnd   = slotStart + this.SLOT_DURATION_MINUTES;
- 
+
     return occupiedRanges.some(
-      (range) => slotStart < range.endMinutes && slotEnd > range.startMinutes,
+      (range) =>
+        range.dayOfWeek === slotDayOfWeek &&
+        slotStart < range.endMinutes &&
+        slotEnd > range.startMinutes,
     );
   }
  
@@ -1023,14 +1028,15 @@ export class AvailabilityService {
     for (const ss of activeSessions) {
       if (!result.has(ss.idTutor)) result.set(ss.idTutor, []);
       result.get(ss.idTutor)!.push({
+        dayOfWeek:    ss.availability.dayOfWeek,
         startMinutes: this.timeToMinutes(ss.session.startTime),
         endMinutes:   this.timeToMinutes(ss.session.endTime),
       });
     }
- 
+
     return result;
   }
- 
+
   private async buildOccupiedRangesForTutor(
     tutorId: string,
     weekStartStr: string,

--- a/src/modules/tutor/dto/complete-tutor-profile.dto.ts
+++ b/src/modules/tutor/dto/complete-tutor-profile.dto.ts
@@ -24,7 +24,7 @@ export class CompleteTutorProfileDto {
 
   @IsInt()
   @Min(1, { message: 'Debe agendar mínimo 1 hora semanal' })
-  @Max(40, { message: 'Máximo 40 horas semanales' })
+  @Max(8, { message: 'Máximo 8 horas semanales' })
   max_weekly_hours!: number;
 
   @IsArray()

--- a/src/modules/tutor/dto/update-tutor-profile.dto.ts
+++ b/src/modules/tutor/dto/update-tutor-profile.dto.ts
@@ -24,7 +24,7 @@ export class UpdateTutorProfileDto {
 
   @IsInt()
   @Min(1, { message: 'Debe agendar mínimo 1 hora semanal' })
-  @Max(40, { message: 'Máximo 40 horas semanales' })
+  @Max(8, { message: 'Máximo 8 horas semanales' })
   max_weekly_hours?: number;
 
   @IsArray()


### PR DESCRIPTION
# Descripción

Se implementa una nueva funcionalidad no contemplada previamente para el front: Dado que para mostrar las disponibilidades de un tutor, se valida si los slots están disponibles o no, recordando que un slot es un espacio de 30 minutos que corresponde a un día de la semana (no relativo a una fecha), naturalmente, cuando hay una sesión que ocupa uno o varios slots, estos no se muestran para que las demás personas no puedan agendar, sin embargo, antes de esta implementación, esto implicaba que el slot no se iba a mostrar en la semana actual, pero tampoco en las siguientes. Ahora, se añade un parámetro a ese proceso: la referencia de la semana, de modo que no existe ese problema y el front tiene acceso a la disponibilidad por semana del tutor.

## Tipo de cambio
- [X] Bug fix (arreglo de error)
- [X] Nueva funcionalidad
- [ ] Cambio breaking (cambio que requiere ajustes en otras partes)
- [ ] Mejora de rendimiento
- [ ] Refactorización (sin cambios funcionales)
- [ ] Documentación

## ¿Cómo se probó?
- [ ] Tests unitarios
- [X] Tests de integración
- [ ] Pruebas manuales

## Checklist
- [X] Mi código sigue las guías de estilo del proyecto
- [X] Actualicé la documentación correspondiente
- [X] Los tests pasan localmente
- [X] No hay conflictos con la rama principal

