### PR TITLE
Fix/availability daily hours limit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,24 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   // Prefijo global para todos los endpoints
   app.setGlobalPrefix('api/v1');
+
+  // Validar DTOs globalmente
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true, // Elimina propiedades no definidas en el DTO
+      forbidNonWhitelisted: true, // Lanza error si hay propiedades extra
+      transform: true, // Transforma tipos automáticamente
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ async function bootstrap() {
   app.setGlobalPrefix('api/v1');
 
   // Validar DTOs globalmente
-  app.useGlobalPipes(
+  /*app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true, // Elimina propiedades no definidas en el DTO
       forbidNonWhitelisted: true, // Lanza error si hay propiedades extra
@@ -18,6 +18,7 @@ async function bootstrap() {
       },
     }),
   );
+  */
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/src/modules/availability/controllers/availability.controller.ts
+++ b/src/modules/availability/controllers/availability.controller.ts
@@ -41,7 +41,7 @@ import { buildPaginatedResponse } from '../../common/helpers/pagination.helper';
     whitelist: true,
     forbidNonWhitelisted: true,
     transform: true,
-  })
+  }),
 )
 export class AvailabilityController {
   constructor(

--- a/src/modules/availability/controllers/availability.controller.ts
+++ b/src/modules/availability/controllers/availability.controller.ts
@@ -36,6 +36,13 @@ import { GetAvailabilityQueryDto } from '../dto/GetAvailabilityQueryDto';
 import { buildPaginatedResponse } from '../../common/helpers/pagination.helper';
 
 @Controller('availability')
+@UsePipes(
+  new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+  })
+)
 export class AvailabilityController {
   constructor(
     private readonly subjectsService: SubjectsService,
@@ -48,14 +55,6 @@ export class AvailabilityController {
   // Visualizar mi disponibilidad como tutor
   //====================================================
   @Get('tutors/me')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   @Roles(UserRole.TUTOR)
   async getMyAvailability(
     @CurrentUser() user: User,
@@ -77,13 +76,6 @@ export class AvailabilityController {
   // RF-14: Visualizar tutores por materia (Código o Nombre) con su disponibilidad
   //====================================================
   @Get('tutors/subject')
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   async getTutorsBySubject(@Query() filters: FilterTutorsDto) {
     if (!filters.subjectId && !filters.subjectName) {
       throw new BadRequestException(
@@ -136,14 +128,6 @@ export class AvailabilityController {
    * Solo accesible para usuarios con rol TUTOR
    */
   @Post('tutor/slots')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   @Roles(UserRole.TUTOR)
   async manageSlot(
     @CurrentUser() user: User,
@@ -217,14 +201,6 @@ export class AvailabilityController {
   // Actualizar límite semanal máximo agendable (solo TUTOR autenticado)
   //====================================================
   @Patch('tutor/me/limits')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   @Roles(UserRole.TUTOR)
   @HttpCode(HttpStatus.OK)
   async updateMyWeeklyHoursLimit(
@@ -254,15 +230,6 @@ export class AvailabilityController {
    * Crea múltiples slots de 30 minutos en un rango horario para el tutor autenticado.
    */
   @Post('tutor/slots/range')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(UserRole.TUTOR)
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   @HttpCode(HttpStatus.CREATED)
   async createSlotsInRange(
     @CurrentUser() user: User,
@@ -285,15 +252,6 @@ export class AvailabilityController {
    * Actualiza la modalidad de las franjas dentro de un rango para el tutor autenticado.
    */
   @Patch('tutor/slots/range')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(UserRole.TUTOR)
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   @HttpCode(HttpStatus.OK)
   async updateSlotsInRange(
     @CurrentUser() user: User,
@@ -316,15 +274,6 @@ export class AvailabilityController {
    * Elimina las franjas dentro de un rango para el tutor autenticado.
    */
   @Delete('tutor/slots/range')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(UserRole.TUTOR)
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   @HttpCode(HttpStatus.OK)
   async deleteSlotsInRange(
     @CurrentUser() user: User,
@@ -352,13 +301,6 @@ export class AvailabilityController {
    * - modality: PRES/VIRT (filtrar por modalidad)
    */
   @Get('tutors/:tutorId/slots')
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   async getTutorAvailability(
     @Param('tutorId', ParseUUIDPipe) tutorId: string,
     @Query() query: GetAvailabilityQueryDto,
@@ -377,13 +319,6 @@ export class AvailabilityController {
    * Útil para mostrar un directorio de tutores disponibles
    */
   @Get('tutors/slots')
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  )
   async getAllAvailableTutors(@Query() query: GetAvailabilityQueryDto) {
     return await this.availabilityService.getAllAvailableTutors({
       modality: query.modality,

--- a/src/modules/availability/controllers/availability.controller.ts
+++ b/src/modules/availability/controllers/availability.controller.ts
@@ -55,6 +55,7 @@ export class AvailabilityController {
   // Visualizar mi disponibilidad como tutor
   //====================================================
   @Get('tutors/me')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.TUTOR)
   async getMyAvailability(
     @CurrentUser() user: User,
@@ -76,6 +77,8 @@ export class AvailabilityController {
   // RF-14: Visualizar tutores por materia (Código o Nombre) con su disponibilidad
   //====================================================
   @Get('tutors/subject')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.STUDENT, UserRole.TUTOR, UserRole.ADMIN)
   async getTutorsBySubject(@Query() filters: FilterTutorsDto) {
     if (!filters.subjectId && !filters.subjectName) {
       throw new BadRequestException(
@@ -128,6 +131,7 @@ export class AvailabilityController {
    * Solo accesible para usuarios con rol TUTOR
    */
   @Post('tutor/slots')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.TUTOR)
   async manageSlot(
     @CurrentUser() user: User,
@@ -201,6 +205,7 @@ export class AvailabilityController {
   // Actualizar límite semanal máximo agendable (solo TUTOR autenticado)
   //====================================================
   @Patch('tutor/me/limits')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.TUTOR)
   @HttpCode(HttpStatus.OK)
   async updateMyWeeklyHoursLimit(
@@ -230,6 +235,8 @@ export class AvailabilityController {
    * Crea múltiples slots de 30 minutos en un rango horario para el tutor autenticado.
    */
   @Post('tutor/slots/range')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR)
   @HttpCode(HttpStatus.CREATED)
   async createSlotsInRange(
     @CurrentUser() user: User,
@@ -252,6 +259,8 @@ export class AvailabilityController {
    * Actualiza la modalidad de las franjas dentro de un rango para el tutor autenticado.
    */
   @Patch('tutor/slots/range')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR)
   @HttpCode(HttpStatus.OK)
   async updateSlotsInRange(
     @CurrentUser() user: User,
@@ -274,6 +283,8 @@ export class AvailabilityController {
    * Elimina las franjas dentro de un rango para el tutor autenticado.
    */
   @Delete('tutor/slots/range')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.TUTOR)
   @HttpCode(HttpStatus.OK)
   async deleteSlotsInRange(
     @CurrentUser() user: User,
@@ -301,6 +312,8 @@ export class AvailabilityController {
    * - modality: PRES/VIRT (filtrar por modalidad)
    */
   @Get('tutors/:tutorId/slots')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.STUDENT, UserRole.TUTOR, UserRole.ADMIN)
   async getTutorAvailability(
     @Param('tutorId', ParseUUIDPipe) tutorId: string,
     @Query() query: GetAvailabilityQueryDto,
@@ -319,6 +332,8 @@ export class AvailabilityController {
    * Útil para mostrar un directorio de tutores disponibles
    */
   @Get('tutors/slots')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.STUDENT, UserRole.TUTOR, UserRole.ADMIN)
   async getAllAvailableTutors(@Query() query: GetAvailabilityQueryDto) {
     return await this.availabilityService.getAllAvailableTutors({
       modality: query.modality,

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -391,7 +391,7 @@ describe('AvailabilityService', () => {
       tutorHaveAvailabilityRepository.findOne
         .mockResolvedValueOnce(tutorAvailability)
         .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null);
+        .mockResolvedValueOnce({ idAvailability: 6, idTutor: 'tutor-1' });
 
       const qb = createQueryBuilderMock();
       qb.getCount.mockResolvedValue(0);
@@ -468,15 +468,17 @@ describe('AvailabilityService', () => {
         availability: { dayOfWeek: 0, startTime: '08:00', idAvailability: 5 },
       };
 
+      // First findOne: returns existing tutor availability for the slot being updated
       tutorHaveAvailabilityRepository.findOne
         .mockResolvedValueOnce(tutorAvailability)
-        .mockResolvedValueOnce(null)
+        // Third findOne: returns conflicting assignment at new time
         .mockResolvedValueOnce({ idAvailability: 6, idTutor: 'tutor-1' });
 
       const qb = createQueryBuilderMock();
       qb.getCount.mockResolvedValue(0);
       tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
 
+      // Second findOne: availabilityRepository finds the availability at new time
       availabilityRepository.findOne.mockResolvedValue({
         idAvailability: 6,
         dayOfWeek: 0,

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -174,25 +174,6 @@ describe('AvailabilityService', () => {
         }),
       ).rejects.toBeInstanceOf(ConflictException);
     });
-
-    it('throws VALIDATION_01 when the daily slot limit is exceeded', async () => {
-      const qb = createQueryBuilderMock();
-      qb.getCount.mockResolvedValueOnce(7).mockResolvedValueOnce(0);
-      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
-
-      await expect(
-        service.createSlotsInRange('tutor-1', {
-          dayOfWeek: DayOfWeek.MONDAY,
-          startTime: '08:00',
-          endTime: '09:00',
-          modality: Modality.PRES,
-        }),
-      ).rejects.toMatchObject({
-        response: {
-          errorCode: 'VALIDATION_01',
-        },
-      });
-    });
   });
 
   describe('updateSlotsInRange', () => {
@@ -395,20 +376,6 @@ describe('AvailabilityService', () => {
           modality: Modality.PRES,
         }),
       ).rejects.toBeInstanceOf(ConflictException);
-    });
-
-    it('throws BadRequestException when daily hours limit is exceeded', async () => {
-      const qb = createQueryBuilderMock();
-      qb.getCount.mockResolvedValueOnce(8).mockResolvedValueOnce(1);
-      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
-
-      await expect(
-        service.createSlot('tutor-1', {
-          dayOfWeek: DayOfWeek.MONDAY,
-          startTime: '08:00',
-          modality: Modality.PRES,
-        }),
-      ).rejects.toBeInstanceOf(BadRequestException);
     });
   });
 

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -39,6 +39,7 @@ describe('AvailabilityService', () => {
     };
 
     tutorHaveAvailabilityRepository = {
+      find: jest.fn(),
       findOne: jest.fn(),
       create: jest.fn((value) => value),
       save: jest.fn(),

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -565,14 +565,22 @@ describe('AvailabilityService', () => {
           idTutor: 'tutor-1',
           idAvailability: 10,
           modality: Modality.PRES,
-          availability: { idAvailability: 10, dayOfWeek: 0, startTime: '08:00' },
+          availability: {
+            idAvailability: 10,
+            dayOfWeek: 0,
+            startTime: '08:00',
+          },
           tutor: { user: { name: 'John Tutor' } },
         },
         {
           idTutor: 'tutor-1',
           idAvailability: 11,
           modality: Modality.PRES,
-          availability: { idAvailability: 11, dayOfWeek: 0, startTime: '08:30' },
+          availability: {
+            idAvailability: 11,
+            dayOfWeek: 0,
+            startTime: '08:30',
+          },
           tutor: { user: { name: 'John Tutor' } },
         },
       ];
@@ -614,7 +622,11 @@ describe('AvailabilityService', () => {
           idTutor: 'tutor-1',
           idAvailability: 10,
           modality: Modality.PRES,
-          availability: { idAvailability: 10, dayOfWeek: 0, startTime: '08:00' },
+          availability: {
+            idAvailability: 10,
+            dayOfWeek: 0,
+            startTime: '08:00',
+          },
           tutor: { user: { name: 'John Tutor' } },
         },
       ];
@@ -646,14 +658,22 @@ describe('AvailabilityService', () => {
           idTutor: 'tutor-1',
           idAvailability: 10,
           modality: Modality.PRES,
-          availability: { idAvailability: 10, dayOfWeek: 0, startTime: '08:00' },
+          availability: {
+            idAvailability: 10,
+            dayOfWeek: 0,
+            startTime: '08:00',
+          },
           tutor: { user: { name: 'John Tutor' } },
         },
         {
           idTutor: 'tutor-1',
           idAvailability: 11,
           modality: Modality.PRES,
-          availability: { idAvailability: 11, dayOfWeek: 0, startTime: '08:30' },
+          availability: {
+            idAvailability: 11,
+            dayOfWeek: 0,
+            startTime: '08:30',
+          },
           tutor: { user: { name: 'John Tutor' } },
         },
       ];
@@ -920,14 +940,22 @@ describe('AvailabilityService', () => {
           idAvailability: 10,
           modality: Modality.PRES,
           availability: { dayOfWeek: 0, startTime: '08:00' },
-          tutor: { isActive: true, profile_completed: true, user: { name: 'John Tutor' } },
+          tutor: {
+            isActive: true,
+            profile_completed: true,
+            user: { name: 'John Tutor' },
+          },
         },
         {
           idTutor: 'tutor-1',
           idAvailability: 11,
           modality: Modality.PRES,
           availability: { dayOfWeek: 0, startTime: '08:30' },
-          tutor: { isActive: true, profile_completed: true, user: { name: 'John Tutor' } },
+          tutor: {
+            isActive: true,
+            profile_completed: true,
+            user: { name: 'John Tutor' },
+          },
         },
       ]);
 
@@ -935,7 +963,9 @@ describe('AvailabilityService', () => {
 
       const scheduledQb = createQueryBuilderMock();
       scheduledQb.getMany.mockResolvedValue([]);
-      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(
+        scheduledQb,
+      );
 
       const result = await service.getAllAvailableTutors();
 
@@ -957,7 +987,11 @@ describe('AvailabilityService', () => {
           idAvailability: 10,
           modality: Modality.PRES,
           availability: { dayOfWeek: 0, startTime: '08:00' },
-          tutor: { isActive: true, profile_completed: true, user: { name: 'John Tutor' } },
+          tutor: {
+            isActive: true,
+            profile_completed: true,
+            user: { name: 'John Tutor' },
+          },
         },
       ]);
 
@@ -965,7 +999,9 @@ describe('AvailabilityService', () => {
 
       const scheduledQb = createQueryBuilderMock();
       scheduledQb.getMany.mockResolvedValue([]);
-      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(
+        scheduledQb,
+      );
 
       const result = await service.getAllAvailableTutors({
         modality: Modality.PRES,
@@ -983,14 +1019,22 @@ describe('AvailabilityService', () => {
           idAvailability: 10,
           modality: Modality.PRES,
           availability: { dayOfWeek: 0, startTime: '08:00' },
-          tutor: { isActive: true, profile_completed: true, user: { name: 'John Tutor' } },
+          tutor: {
+            isActive: true,
+            profile_completed: true,
+            user: { name: 'John Tutor' },
+          },
         },
         {
           idTutor: 'tutor-2',
           idAvailability: 20,
           modality: Modality.VIRT,
           availability: { dayOfWeek: 0, startTime: '09:00' },
-          tutor: { isActive: true, profile_completed: true, user: { name: 'Jane Tutor' } },
+          tutor: {
+            isActive: true,
+            profile_completed: true,
+            user: { name: 'Jane Tutor' },
+          },
         },
       ]);
 
@@ -1008,7 +1052,9 @@ describe('AvailabilityService', () => {
         ]) // tutor-1 has occupied slot
         .mockResolvedValueOnce([]); // tutor-2 has available slots
 
-      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(
+        scheduledQb,
+      );
 
       const result = await service.getAllAvailableTutors({
         onlyAvailable: true,
@@ -1033,7 +1079,11 @@ describe('AvailabilityService', () => {
           idTutor: 'tutor-1',
           idAvailability: 10,
           modality: Modality.PRES,
-          availability: { dayOfWeek: 0, startTime: '08:00', idAvailability: 10 },
+          availability: {
+            dayOfWeek: 0,
+            startTime: '08:00',
+            idAvailability: 10,
+          },
           tutor: { user: { name: 'John Tutor' } },
         },
       ]);
@@ -1045,9 +1095,12 @@ describe('AvailabilityService', () => {
 
       const scheduledQb = createQueryBuilderMock();
       scheduledQb.getMany.mockResolvedValue([]);
-      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(
+        scheduledQb,
+      );
 
-      const result = await service.getTutorsBySubjectWithAvailability('subject-1');
+      const result =
+        await service.getTutorsBySubjectWithAvailability('subject-1');
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -1081,7 +1134,9 @@ describe('AvailabilityService', () => {
 
       const scheduledQb = createQueryBuilderMock();
       scheduledQb.getMany.mockResolvedValue([]);
-      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(
+        scheduledQb,
+      );
 
       const result = await service.getTutorsBySubjectWithAvailability(
         'subject-1',
@@ -1100,9 +1155,8 @@ describe('AvailabilityService', () => {
         eligibleQb,
       );
 
-      const result = await service.getTutorsBySubjectWithAvailability(
-        'subject-999',
-      );
+      const result =
+        await service.getTutorsBySubjectWithAvailability('subject-999');
 
       expect(result).toEqual({
         tutors: [],
@@ -1133,7 +1187,9 @@ describe('AvailabilityService', () => {
 
       const scheduledQb = createQueryBuilderMock();
       scheduledQb.getMany.mockResolvedValue([]);
-      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(
+        scheduledQb,
+      );
 
       const result = await service.getTutorsBySubjectWithAvailability(
         'subject-1',

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -143,6 +143,23 @@ describe('AvailabilityService', () => {
       });
     });
 
+    it('throws VALIDATION_01 when time boundaries are not aligned to 30-minute increments', async () => {
+      await expect(
+        service.createSlotsInRange('tutor-1', {
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:15',
+          endTime: '09:00',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          errorCode: 'VALIDATION_01',
+          message:
+            'La hora de inicio y fin deben estar alineadas a intervalos de 30 minutos',
+        },
+      });
+    });
+
     it('throws CONFLICT_01 when the tutor already has overlapping slots', async () => {
       const qb = createQueryBuilderMock();
       qb.getCount.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
@@ -306,21 +323,6 @@ describe('AvailabilityService', () => {
       });
     });
 
-    it('throws VALIDATION_01 when delete range is not in 30-minute increments', async () => {
-      await expect(
-        service.deleteSlotsInRange('tutor-1', {
-          dayOfWeek: DayOfWeek.WEDNESDAY,
-          startTime: '14:15',
-          endTime: '15:00',
-          modality: Modality.PRES,
-        }),
-      ).rejects.toMatchObject({
-        response: {
-          errorCode: 'VALIDATION_01',
-        },
-      });
-    });
-
     it('throws RESOURCE_02 if there are no slots to delete', async () => {
       const qb = createQueryBuilderMock();
       qb.getMany.mockResolvedValue([]);
@@ -341,54 +343,804 @@ describe('AvailabilityService', () => {
     });
   });
 
-  describe('createSlotTimes validation helper behavior via public methods', () => {
-    it('throws VALIDATION_01 when the range is not in 30-minute increments', async () => {
-      await expect(
-        service.createSlotsInRange('tutor-1', {
-          dayOfWeek: DayOfWeek.MONDAY,
-          startTime: '08:15',
-          endTime: '09:00',
-          modality: Modality.PRES,
-        }),
-      ).rejects.toMatchObject({
-        response: {
-          errorCode: 'VALIDATION_01',
-        },
+  describe('createSlot', () => {
+    it('creates a single availability slot for a tutor', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValue(0);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+      availabilityRepository.findOne.mockResolvedValue(null);
+      availabilityRepository.save.mockResolvedValue({
+        idAvailability: 1,
+        dayOfWeek: 0,
+        startTime: '08:00',
       });
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.createSlot('tutor-1', {
+        dayOfWeek: DayOfWeek.MONDAY,
+        startTime: '08:00',
+        modality: Modality.PRES,
+      });
+
+      expect(result).toEqual({
+        slotId: 1,
+        tutorId: 'tutor-1',
+        dayOfWeek: DayOfWeek.MONDAY,
+        startTime: '08:00',
+        modality: Modality.PRES,
+        duration: 0.5,
+      });
+      expect(availabilityRepository.save).toHaveBeenCalled();
+      expect(tutorHaveAvailabilityRepository.save).toHaveBeenCalled();
     });
 
-    it('throws VALIDATION_01 when start and end are not aligned to :00/:30 boundaries', async () => {
-      await expect(
-        service.createSlotsInRange('tutor-1', {
-          dayOfWeek: DayOfWeek.MONDAY,
-          startTime: '08:15',
-          endTime: '09:15',
-          modality: Modality.PRES,
-        }),
-      ).rejects.toMatchObject({
-        response: {
-          errorCode: 'VALIDATION_01',
-          message:
-            'La hora de inicio y fin deben estar alineadas a intervalos de 30 minutos',
-        },
+    it('throws ConflictException when tutor already has that slot assigned', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValue(0);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+      availabilityRepository.findOne.mockResolvedValue({
+        idAvailability: 1,
+        dayOfWeek: 0,
+        startTime: '08:00',
       });
-    });
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue({
+        idTutor: 'tutor-1',
+        idAvailability: 1,
+      });
 
-    it('throws VALIDATION_01 when only endTime is not aligned to :00/:30 boundaries', async () => {
       await expect(
-        service.updateSlotsInRange('tutor-1', {
+        service.createSlot('tutor-1', {
           dayOfWeek: DayOfWeek.MONDAY,
           startTime: '08:00',
-          endTime: '09:15',
           modality: Modality.PRES,
         }),
-      ).rejects.toMatchObject({
-        response: {
-          errorCode: 'VALIDATION_01',
-          message:
-            'La hora de inicio y fin deben estar alineadas a intervalos de 30 minutos',
-        },
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('throws BadRequestException when daily hours limit is exceeded', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValueOnce(8).mockResolvedValueOnce(1);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.createSlot('tutor-1', {
+          dayOfWeek: DayOfWeek.MONDAY,
+          startTime: '08:00',
+          modality: Modality.PRES,
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('updateSlot', () => {
+    it('updates the startTime of an existing slot', async () => {
+      const tutorAvailability = {
+        idTutor: 'tutor-1',
+        idAvailability: 5,
+        modality: Modality.PRES,
+        availability: { dayOfWeek: 0, startTime: '08:00', idAvailability: 5 },
+      };
+
+      tutorHaveAvailabilityRepository.findOne
+        .mockResolvedValueOnce(tutorAvailability)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValue(0);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      availabilityRepository.findOne.mockResolvedValue(null);
+      availabilityRepository.save.mockResolvedValue({
+        idAvailability: 6,
+        dayOfWeek: 0,
+        startTime: '09:00',
       });
+
+      const result = await service.updateSlot('tutor-1', {
+        slotId: 5,
+        startTime: '09:00',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          slotId: 6,
+          tutorId: 'tutor-1',
+          startTime: '09:00',
+        }),
+      );
+      expect(tutorHaveAvailabilityRepository.remove).toHaveBeenCalledWith(
+        tutorAvailability,
+      );
+    });
+
+    it('updates only the modality if startTime is not provided', async () => {
+      const tutorAvailability = {
+        idTutor: 'tutor-1',
+        idAvailability: 5,
+        modality: Modality.PRES,
+        availability: { dayOfWeek: 0, startTime: '08:00', idAvailability: 5 },
+      };
+
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(
+        tutorAvailability,
+      );
+
+      const result = await service.updateSlot('tutor-1', {
+        slotId: 5,
+        modality: Modality.VIRT,
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          slotId: 5,
+          modality: Modality.VIRT,
+        }),
+      );
+      expect(tutorHaveAvailabilityRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ modality: Modality.VIRT }),
+      );
+    });
+
+    it('throws NotFoundException if slot does not belong to tutor', async () => {
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateSlot('tutor-1', {
+          slotId: 999,
+          modality: Modality.VIRT,
+        }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws ConflictException if new time slot already assigned to tutor', async () => {
+      const tutorAvailability = {
+        idTutor: 'tutor-1',
+        idAvailability: 5,
+        modality: Modality.PRES,
+        availability: { dayOfWeek: 0, startTime: '08:00', idAvailability: 5 },
+      };
+
+      tutorHaveAvailabilityRepository.findOne
+        .mockResolvedValueOnce(tutorAvailability)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ idAvailability: 6, idTutor: 'tutor-1' });
+
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValue(0);
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      availabilityRepository.findOne.mockResolvedValue({
+        idAvailability: 6,
+        dayOfWeek: 0,
+        startTime: '09:00',
+      });
+
+      await expect(
+        service.updateSlot('tutor-1', {
+          slotId: 5,
+          startTime: '09:00',
+        }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+  });
+
+  describe('deleteSlot', () => {
+    it('deletes an availability slot', async () => {
+      const tutorAvailability = {
+        idTutor: 'tutor-1',
+        idAvailability: 5,
+        modality: Modality.PRES,
+      };
+
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(
+        tutorAvailability,
+      );
+      tutorHaveAvailabilityRepository.remove.mockResolvedValue({});
+
+      const result = await service.deleteSlot('tutor-1', { slotId: 5 });
+
+      expect(result).toEqual({
+        message: 'Franja de disponibilidad eliminada exitosamente',
+        slotId: 5,
+      });
+      expect(tutorHaveAvailabilityRepository.remove).toHaveBeenCalledWith(
+        tutorAvailability,
+      );
+    });
+
+    it('throws NotFoundException if slot does not belong to tutor', async () => {
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.deleteSlot('tutor-1', { slotId: 999 }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('getTutorAvailability', () => {
+    it('returns availability slots with correct isAvailable status when no sessions are scheduled', async () => {
+      const tutorAvailabilities = [
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          modality: Modality.PRES,
+          availability: { idAvailability: 10, dayOfWeek: 0, startTime: '08:00' },
+          tutor: { user: { name: 'John Tutor' } },
+        },
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 11,
+          modality: Modality.PRES,
+          availability: { idAvailability: 11, dayOfWeek: 0, startTime: '08:30' },
+          tutor: { user: { name: 'John Tutor' } },
+        },
+      ];
+
+      tutorHaveAvailabilityRepository.find.mockResolvedValue(
+        tutorAvailabilities,
+      );
+
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTutorAvailability('tutor-1');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          tutorId: 'tutor-1',
+          tutorName: 'John Tutor',
+          totalSlots: 2,
+          availableSlots: expect.arrayContaining([
+            expect.objectContaining({
+              slotId: '10',
+              startTime: '08:00',
+              isAvailable: true,
+            }),
+            expect.objectContaining({
+              slotId: '11',
+              startTime: '08:30',
+              isAvailable: true,
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('marks slots as unavailable when they have active sessions', async () => {
+      const tutorAvailabilities = [
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          modality: Modality.PRES,
+          availability: { idAvailability: 10, dayOfWeek: 0, startTime: '08:00' },
+          tutor: { user: { name: 'John Tutor' } },
+        },
+      ];
+
+      tutorHaveAvailabilityRepository.find.mockResolvedValue(
+        tutorAvailabilities,
+      );
+
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          availability: { dayOfWeek: 0, startTime: '08:00' },
+          session: { startTime: '08:00', endTime: '08:30' },
+        },
+      ]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTutorAvailability('tutor-1');
+
+      expect(result.availableSlots).toHaveLength(0);
+      expect(result.totalSlots).toBe(1);
+    });
+
+    it('filters slots by onlyAvailable option', async () => {
+      const tutorAvailabilities = [
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          modality: Modality.PRES,
+          availability: { idAvailability: 10, dayOfWeek: 0, startTime: '08:00' },
+          tutor: { user: { name: 'John Tutor' } },
+        },
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 11,
+          modality: Modality.PRES,
+          availability: { idAvailability: 11, dayOfWeek: 0, startTime: '08:30' },
+          tutor: { user: { name: 'John Tutor' } },
+        },
+      ];
+
+      tutorHaveAvailabilityRepository.find.mockResolvedValue(
+        tutorAvailabilities,
+      );
+
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTutorAvailability('tutor-1', {
+        onlyAvailable: true,
+      });
+
+      expect(result.availableSlots).toHaveLength(2);
+    });
+
+    it('throws NotFoundException if tutor has no availability configured', async () => {
+      tutorHaveAvailabilityRepository.find.mockResolvedValue([]);
+
+      await expect(
+        service.getTutorAvailability('tutor-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('getAvailabilityById', () => {
+    it('returns availability slot by id', async () => {
+      const availability = {
+        idAvailability: 5,
+        dayOfWeek: 0,
+        startTime: '08:00',
+      };
+
+      availabilityRepository.findOne.mockResolvedValue(availability);
+
+      const result = await service.getAvailabilityById(5);
+
+      expect(result).toEqual(availability);
+    });
+
+    it('throws NotFoundException if availability does not exist', async () => {
+      availabilityRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getAvailabilityById(999)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('validateModalityForSlot', () => {
+    it('validates that slot modality matches requested modality', async () => {
+      const tutorAvailability = {
+        idTutor: 'tutor-1',
+        idAvailability: 10,
+        modality: Modality.PRES,
+      };
+
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(
+        tutorAvailability,
+      );
+
+      await expect(
+        service.validateModalityForSlot(10, 'tutor-1', Modality.PRES),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws BadRequestException if modality does not match', async () => {
+      const tutorAvailability = {
+        idTutor: 'tutor-1',
+        idAvailability: 10,
+        modality: Modality.PRES,
+      };
+
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(
+        tutorAvailability,
+      );
+
+      await expect(
+        service.validateModalityForSlot(10, 'tutor-1', Modality.VIRT),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws NotFoundException if slot does not belong to tutor', async () => {
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.validateModalityForSlot(10, 'tutor-1', Modality.PRES),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('isSlotAvailableForDate', () => {
+    it('returns true if slot has no active session on that date', async () => {
+      scheduledSessionRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.isSlotAvailableForDate(
+        'tutor-1',
+        10,
+        '2024-01-15',
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true if slot has an inactive session on that date', async () => {
+      const scheduledSession = {
+        idTutor: 'tutor-1',
+        idAvailability: 10,
+        scheduledDate: '2024-01-15',
+        session: { status: 'CANCELLED' },
+      };
+
+      scheduledSessionRepository.findOne.mockResolvedValue(scheduledSession);
+
+      const result = await service.isSlotAvailableForDate(
+        'tutor-1',
+        10,
+        '2024-01-15',
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false if slot has an active SCHEDULED session', async () => {
+      const scheduledSession = {
+        idTutor: 'tutor-1',
+        idAvailability: 10,
+        scheduledDate: '2024-01-15',
+        session: { status: 'SCHEDULED' },
+      };
+
+      scheduledSessionRepository.findOne.mockResolvedValue(scheduledSession);
+
+      const result = await service.isSlotAvailableForDate(
+        'tutor-1',
+        10,
+        '2024-01-15',
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isSlotAvailableForDateWithDuration', () => {
+    it('returns available: true if slot and duration coverage are valid', async () => {
+      availabilityRepository.findOne.mockResolvedValue({
+        idAvailability: 10,
+        dayOfWeek: 0,
+        startTime: '08:00',
+      });
+
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValueOnce(2); // 2 slots needed for 1 hour
+      qb.getMany.mockResolvedValue([]); // No overlapping sessions
+
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.isSlotAvailableForDateWithDuration(
+        'tutor-1',
+        10,
+        '2024-01-15',
+        1,
+      );
+
+      expect(result).toEqual({ available: true });
+    });
+
+    it('returns available: false if tutor lacks sufficient slots for duration', async () => {
+      availabilityRepository.findOne.mockResolvedValue({
+        idAvailability: 10,
+        dayOfWeek: 0,
+        startTime: '08:00',
+      });
+
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValueOnce(1); // Only 1 slot, but 2 needed for 1 hour
+
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.isSlotAvailableForDateWithDuration(
+        'tutor-1',
+        10,
+        '2024-01-15',
+        1,
+      );
+
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain('no tiene disponibilidad registrada');
+    });
+
+    it('returns available: false if there is a session overlap', async () => {
+      availabilityRepository.findOne.mockResolvedValue({
+        idAvailability: 10,
+        dayOfWeek: 0,
+        startTime: '08:00',
+      });
+
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValueOnce(2); // Slots coverage is OK
+      qb.getMany.mockResolvedValue([
+        {
+          idSession: 'session-1',
+          idTutor: 'tutor-1',
+          availability: { startTime: '08:00' },
+          session: { startTime: '08:00', endTime: '09:00' },
+        },
+      ]); // Overlapping session
+
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(qb);
+      sessionRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.isSlotAvailableForDateWithDuration(
+        'tutor-1',
+        10,
+        '2024-01-15',
+        1,
+      );
+
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain('se solapa con una sesión activa');
+    });
+
+    it('excludes specified session when checking for overlaps', async () => {
+      availabilityRepository.findOne.mockResolvedValue({
+        idAvailability: 10,
+        dayOfWeek: 0,
+        startTime: '08:00',
+      });
+
+      const qb = createQueryBuilderMock();
+      qb.getCount.mockResolvedValueOnce(2);
+      qb.getMany.mockResolvedValue([]); // Query builder configured to exclude session
+
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.isSlotAvailableForDateWithDuration(
+        'tutor-1',
+        10,
+        '2024-01-15',
+        1,
+        'session-to-exclude',
+      );
+
+      expect(result.available).toBe(true);
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'ss.idSession != :excludeSessionId',
+        { excludeSessionId: 'session-to-exclude' },
+      );
+    });
+  });
+
+  describe('getAllAvailableTutors', () => {
+    it('returns all tutors with their availability slots', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          modality: Modality.PRES,
+          availability: { dayOfWeek: 0, startTime: '08:00' },
+          tutor: { isActive: true, profile_completed: true, user: { name: 'John Tutor' } },
+        },
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 11,
+          modality: Modality.PRES,
+          availability: { dayOfWeek: 0, startTime: '08:30' },
+          tutor: { isActive: true, profile_completed: true, user: { name: 'John Tutor' } },
+        },
+      ]);
+
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const scheduledQb = createQueryBuilderMock();
+      scheduledQb.getMany.mockResolvedValue([]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+
+      const result = await service.getAllAvailableTutors();
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          tutorId: 'tutor-1',
+          tutorName: 'John Tutor',
+          totalSlots: 2,
+          availableSlots: 2,
+        }),
+      ]);
+    });
+
+    it('filters tutors by modality', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          modality: Modality.PRES,
+          availability: { dayOfWeek: 0, startTime: '08:00' },
+          tutor: { isActive: true, profile_completed: true, user: { name: 'John Tutor' } },
+        },
+      ]);
+
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const scheduledQb = createQueryBuilderMock();
+      scheduledQb.getMany.mockResolvedValue([]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+
+      const result = await service.getAllAvailableTutors({
+        modality: Modality.PRES,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].modalities).toContain(Modality.PRES);
+    });
+
+    it('filters to only available tutors with onlyAvailable option', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          modality: Modality.PRES,
+          availability: { dayOfWeek: 0, startTime: '08:00' },
+          tutor: { isActive: true, profile_completed: true, user: { name: 'John Tutor' } },
+        },
+        {
+          idTutor: 'tutor-2',
+          idAvailability: 20,
+          modality: Modality.VIRT,
+          availability: { dayOfWeek: 0, startTime: '09:00' },
+          tutor: { isActive: true, profile_completed: true, user: { name: 'Jane Tutor' } },
+        },
+      ]);
+
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const scheduledQb = createQueryBuilderMock();
+      scheduledQb.getMany
+        .mockResolvedValueOnce([
+          {
+            idTutor: 'tutor-1',
+            idAvailability: 10,
+            availability: { dayOfWeek: 0, startTime: '08:00' },
+            session: { startTime: '08:00', endTime: '08:30' },
+          },
+        ]) // tutor-1 has occupied slot
+        .mockResolvedValueOnce([]); // tutor-2 has available slots
+
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+
+      const result = await service.getAllAvailableTutors({
+        onlyAvailable: true,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].tutorId).toBe('tutor-2');
+    });
+  });
+
+  describe('getTutorsBySubjectWithAvailability', () => {
+    it('returns tutors with subject expertise and their availability', async () => {
+      const eligibleQb = createQueryBuilderMock();
+      eligibleQb.getRawMany.mockResolvedValue([
+        { tutorId: 'tutor-1' },
+        { tutorId: 'tutor-2' },
+      ]);
+
+      const slotsQb = createQueryBuilderMock();
+      slotsQb.getMany.mockResolvedValue([
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          modality: Modality.PRES,
+          availability: { dayOfWeek: 0, startTime: '08:00', idAvailability: 10 },
+          tutor: { user: { name: 'John Tutor' } },
+        },
+      ]);
+
+      tutorHaveAvailabilityRepository.createQueryBuilder
+        .mockReturnValueOnce(eligibleQb)
+        .mockReturnValueOnce(slotsQb)
+        .mockReturnValueOnce(slotsQb);
+
+      const scheduledQb = createQueryBuilderMock();
+      scheduledQb.getMany.mockResolvedValue([]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+
+      const result = await service.getTutorsBySubjectWithAvailability('subject-1');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          tutors: expect.arrayContaining([
+            expect.objectContaining({
+              tutorId: 'tutor-1',
+              tutorName: 'John Tutor',
+            }),
+          ]),
+          total: expect.any(Number),
+          weekReference: expect.any(String),
+        }),
+      );
+    });
+
+    it('supports pagination with page and limit options', async () => {
+      const eligibleQb = createQueryBuilderMock();
+      eligibleQb.getRawMany.mockResolvedValue([
+        { tutorId: 'tutor-1' },
+        { tutorId: 'tutor-2' },
+        { tutorId: 'tutor-3' },
+      ]);
+
+      const slotsQb = createQueryBuilderMock();
+      slotsQb.getMany.mockResolvedValue([]);
+
+      tutorHaveAvailabilityRepository.createQueryBuilder
+        .mockReturnValueOnce(eligibleQb)
+        .mockReturnValueOnce(slotsQb)
+        .mockReturnValueOnce(slotsQb);
+
+      const scheduledQb = createQueryBuilderMock();
+      scheduledQb.getMany.mockResolvedValue([]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+
+      const result = await service.getTutorsBySubjectWithAvailability(
+        'subject-1',
+        { page: 1, limit: 2 },
+      );
+
+      expect(result.total).toBe(3);
+      expect(result.tutors).toHaveLength(0); // No slots to show for second query
+    });
+
+    it('returns empty result if no eligible tutors found', async () => {
+      const eligibleQb = createQueryBuilderMock();
+      eligibleQb.getRawMany.mockResolvedValue([]);
+
+      tutorHaveAvailabilityRepository.createQueryBuilder.mockReturnValue(
+        eligibleQb,
+      );
+
+      const result = await service.getTutorsBySubjectWithAvailability(
+        'subject-999',
+      );
+
+      expect(result).toEqual({
+        tutors: [],
+        total: 0,
+        weekReference: expect.any(String),
+      });
+    });
+
+    it('filters tutors by modality if provided', async () => {
+      const eligibleQb = createQueryBuilderMock();
+      eligibleQb.getRawMany.mockResolvedValue([{ tutorId: 'tutor-1' }]);
+
+      const slotsQb = createQueryBuilderMock();
+      slotsQb.getMany.mockResolvedValue([
+        {
+          idTutor: 'tutor-1',
+          idAvailability: 10,
+          modality: Modality.PRES,
+          availability: { dayOfWeek: 0, startTime: '08:00' },
+          tutor: { user: { name: 'John Tutor' } },
+        },
+      ]);
+
+      tutorHaveAvailabilityRepository.createQueryBuilder
+        .mockReturnValueOnce(eligibleQb)
+        .mockReturnValueOnce(slotsQb)
+        .mockReturnValueOnce(slotsQb);
+
+      const scheduledQb = createQueryBuilderMock();
+      scheduledQb.getMany.mockResolvedValue([]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(scheduledQb);
+
+      const result = await service.getTutorsBySubjectWithAvailability(
+        'subject-1',
+        { modality: Modality.PRES },
+      );
+
+      expect(result.tutors[0]?.modalities).toContain(Modality.PRES);
     });
   });
 });

--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -663,7 +663,12 @@ describe('AvailabilityService', () => {
     });
 
     it('throws NotFoundException if tutor has no availability configured', async () => {
+      // Ensure mocks are properly reset and set up for this test
       tutorHaveAvailabilityRepository.find.mockResolvedValue([]);
+      // Also ensure scheduledSessionRepository is mocked if getTutorAvailability uses it
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([]);
+      scheduledSessionRepository.createQueryBuilder.mockReturnValue(qb);
 
       await expect(
         service.getTutorAvailability('tutor-1'),

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -77,7 +77,6 @@ interface OccupiedRange {
 @Injectable()
 export class AvailabilityService {
   private readonly SLOT_DURATION_MINUTES = 30;
-  private readonly MAX_SLOTS_PER_DAY = 8;
 
   constructor(
     @InjectRepository(Availability, 'local')
@@ -97,7 +96,6 @@ export class AvailabilityService {
   async createSlot(tutorId: string, dto: CreateSlotDto) {
     const dayOfWeekNumber = DayOfWeekToNumber[dto.dayOfWeek];
     await this.validateNoOverlap(tutorId, dayOfWeekNumber, dto.startTime);
-    await this.validateDailyHoursLimit(tutorId, dayOfWeekNumber);
 
     let availability = await this.availabilityRepository.findOne({
       where: { dayOfWeek: dayOfWeekNumber, startTime: dto.startTime },
@@ -160,14 +158,6 @@ export class AvailabilityService {
           .where('tha.idTutor = :tutorId', { tutorId })
           .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek: dayOfWeekNumber })
           .getCount();
-
-        if (existingSlotsInDay + slotTimes.length > this.MAX_SLOTS_PER_DAY) {
-          throw new BadRequestException({
-            errorCode: 'VALIDATION_01',
-            message:
-              'Excede el máximo diario de 4 horas. Ya tienes slots registrados para este día.',
-          });
-        }
 
         const overlappingSlots = await tutorHaveAvailabilityRepository
           .createQueryBuilder('tha')
@@ -1263,33 +1253,6 @@ export class AvailabilityService {
       throw new ConflictException(
         'Ya existe otra franja en ese horario para este día',
       );
-    }
-  }
-
-  private async validateDailyHoursLimit(
-    tutorId: string,
-    dayOfWeek: number,
-  ): Promise<void> {
-    const slotsInDay = await this.tutorHaveAvailabilityRepository
-      .createQueryBuilder('tha')
-      .innerJoin('tha.availability', 'a')
-      .where('tha.idTutor = :tutorId', { tutorId })
-      .andWhere('a.dayOfWeek = :dayOfWeek', { dayOfWeek })
-      .getCount();
-
-    if (slotsInDay >= this.MAX_SLOTS_PER_DAY) {
-      const daysWithSlots = await this.tutorHaveAvailabilityRepository
-        .createQueryBuilder('tha')
-        .innerJoin('tha.availability', 'a')
-        .select('DISTINCT a.dayOfWeek', 'day')
-        .where('tha.idTutor = :tutorId', { tutorId })
-        .getRawMany();
-
-      if (daysWithSlots.length > 1) {
-        throw new BadRequestException(
-          'Excede el máximo diario de 4 horas. Ya tienes 8 slots (4 horas) en este día.',
-        );
-      }
     }
   }
 }

--- a/src/modules/scheduling/dto/create-individual-session.dto.ts
+++ b/src/modules/scheduling/dto/create-individual-session.dto.ts
@@ -10,6 +10,7 @@ import {
   IsIn,
 } from 'class-validator';
 import { Modality } from '../../availability/enums';
+import { IsThirtyMinuteIncrement } from '../../availability/validators';
 
 export class CreateIndividualSessionDto {
   @IsUUID('4', { message: 'tutorId debe ser un UUID válido' })
@@ -29,6 +30,9 @@ export class CreateIndividualSessionDto {
 
   @IsNumber()
   @IsIn([0.5, 1, 1.5, 2], { message: 'durationHours debe ser 0.5, 1, 1.5 o 2' })
+  //@IsThirtyMinuteIncrement({
+  //  message: 'durationHours debe estar en incrementos de 0.5 horas (30 minutos)',
+  //})
   durationHours: number; // Se usa para calcular endTime, no se guarda
 
   @IsString()

--- a/src/modules/scheduling/dto/create-individual-session.dto.ts
+++ b/src/modules/scheduling/dto/create-individual-session.dto.ts
@@ -28,7 +28,7 @@ export class CreateIndividualSessionDto {
   modality: Modality;
 
   @IsNumber()
-  @IsIn([1, 1.5, 2], { message: 'durationHours debe ser 1, 1.5 o 2' })
+  @IsIn([0.5, 1, 1.5, 2], { message: 'durationHours debe ser 0.5, 1, 1.5 o 2' })
   durationHours: number; // Se usa para calcular endTime, no se guarda
 
   @IsString()

--- a/src/modules/scheduling/dto/propose-modification.dto.ts
+++ b/src/modules/scheduling/dto/propose-modification.dto.ts
@@ -24,6 +24,6 @@ export class ProposeModificationDto {
 
   @IsOptional()
   @IsNumber()
-  @IsIn([1, 1.5, 2])
+  @IsIn([0.5, 1, 1.5, 2], { message: 'durationHours debe ser 0.5, 1, 1.5 o 2' })
   newDurationHours?: number; // Para calcular nuevo endTime
 }

--- a/src/modules/scheduling/services/session-validation.service.spec.ts
+++ b/src/modules/scheduling/services/session-validation.service.spec.ts
@@ -291,11 +291,17 @@ describe('SessionValidationService', () => {
         ),
       ).resolves.toBeUndefined();
 
-      // Verify andWhere was called to exclude the session
-      expect(qb.andWhere).toHaveBeenCalledWith(
-        'session.idSession != :excludeSessionId',
-        { excludeSessionId: 'session-to-exclude' },
+      // Verify andWhere was called to exclude the session (should be called 4 times total)
+      expect(qb.andWhere).toHaveBeenCalled();
+      // Verify the specific exclude filter was applied
+      const andWhereCalls = qb.andWhere.mock.calls;
+      const excludeCall = andWhereCalls.find(
+        (call: any[]) => call[0]?.includes('idSession !='),
       );
+      expect(excludeCall).toBeDefined();
+      expect(excludeCall?.[1]).toEqual({
+        excludeSessionId: 'session-to-exclude',
+      });
     });
   });
 

--- a/src/modules/scheduling/services/session-validation.service.spec.ts
+++ b/src/modules/scheduling/services/session-validation.service.spec.ts
@@ -296,7 +296,8 @@ describe('SessionValidationService', () => {
       // Verify the specific exclude filter was applied
       const andWhereCalls = qb.andWhere.mock.calls;
       const excludeCall = andWhereCalls.find(
-        (call: any[]) => call[0]?.includes('idSession !='),
+        (call: any[]) =>
+          call[0]?.includes('idSession !='),
       );
       expect(excludeCall).toBeDefined();
       expect(excludeCall?.[1]).toEqual({

--- a/src/modules/scheduling/services/session-validation.service.spec.ts
+++ b/src/modules/scheduling/services/session-validation.service.spec.ts
@@ -7,11 +7,16 @@ describe('SessionValidationService', () => {
   let availabilityService: any;
   let tutorService: any;
 
-  const createQueryBuilderMock = () => ({
-    where: jest.fn().mockReturnThis(),
-    andWhere: jest.fn().mockReturnThis(),
-    getMany: jest.fn(),
-  });
+  const createQueryBuilderMock = () => {
+    const qb: any = {
+      where: jest.fn(),
+      andWhere: jest.fn(),
+      getMany: jest.fn(),
+    };
+    qb.where.mockReturnValue(qb);
+    qb.andWhere.mockReturnValue(qb);
+    return qb;
+  };
 
   beforeEach(() => {
     sessionRepository = {

--- a/src/modules/scheduling/services/session-validation.service.spec.ts
+++ b/src/modules/scheduling/services/session-validation.service.spec.ts
@@ -295,9 +295,8 @@ describe('SessionValidationService', () => {
       expect(qb.andWhere).toHaveBeenCalled();
       // Verify the specific exclude filter was applied
       const andWhereCalls = qb.andWhere.mock.calls;
-      const excludeCall = andWhereCalls.find(
-        (call: any[]) =>
-          call[0]?.includes('idSession !='),
+      const excludeCall = andWhereCalls.find((call: any[]) =>
+        call[0]?.includes('idSession !='),
       );
       expect(excludeCall).toBeDefined();
       expect(excludeCall?.[1]).toEqual({

--- a/src/modules/scheduling/services/session-validation.service.spec.ts
+++ b/src/modules/scheduling/services/session-validation.service.spec.ts
@@ -275,9 +275,9 @@ describe('SessionValidationService', () => {
 
     it('excludes specified session when checking for hours accumulation', async () => {
       const qb = createQueryBuilderMock();
+      // The DB applies the andWhere filter — mock returns only the non-excluded session
       qb.getMany.mockResolvedValue([
-        { startTime: '09:00', endTime: '12:00' }, // 3h (but will be excluded)
-        { startTime: '14:00', endTime: '15:00' }, // 1h
+        { startTime: '14:00', endTime: '15:00' }, // 1h (3h session is excluded by DB query)
       ]);
       sessionRepository.createQueryBuilder.mockReturnValue(qb);
 

--- a/src/modules/scheduling/services/session-validation.service.spec.ts
+++ b/src/modules/scheduling/services/session-validation.service.spec.ts
@@ -212,6 +212,88 @@ describe('SessionValidationService', () => {
     });
   });
 
+  // ─── validateDailyHoursLimit ──────────────────────────────────────────────────
+
+  describe('validateDailyHoursLimit', () => {
+    it('resolves when total daily hours remain below the daily limit', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([{ startTime: '09:00', endTime: '10:00' }]); // 1h used
+      sessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.validateDailyHoursLimit('tutor-1', '2025-04-07', 2), // 1+2=3 ≤ 4
+      ).resolves.toBeUndefined();
+    });
+
+    it('resolves when total daily hours exactly equal the daily limit', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([{ startTime: '09:00', endTime: '12:00' }]); // 3h used
+      sessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.validateDailyHoursLimit('tutor-1', '2025-04-07', 1), // 3+1=4 = 4 (not > 4)
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws BadRequestException when adding hours would exceed the daily limit', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([{ startTime: '09:00', endTime: '12:00' }]); // 3h used
+      sessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.validateDailyHoursLimit('tutor-1', '2025-04-07', 1.5), // 3+1.5=4.5 > 4
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('accumulates hours from multiple existing sessions correctly', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        { startTime: '09:00', endTime: '10:00' }, // 1h
+        { startTime: '14:00', endTime: '16:00' }, // 2h — total 3h
+      ]);
+      sessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.validateDailyHoursLimit('tutor-1', '2025-04-07', 2), // 3+2=5 > 4
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('resolves when there are no existing sessions on that date', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([]); // No sessions
+      sessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.validateDailyHoursLimit('tutor-1', '2025-04-07', 3), // 0+3=3 ≤ 4
+      ).resolves.toBeUndefined();
+    });
+
+    it('excludes specified session when checking for hours accumulation', async () => {
+      const qb = createQueryBuilderMock();
+      qb.getMany.mockResolvedValue([
+        { startTime: '09:00', endTime: '12:00' }, // 3h (but will be excluded)
+        { startTime: '14:00', endTime: '15:00' }, // 1h
+      ]);
+      sessionRepository.createQueryBuilder.mockReturnValue(qb);
+
+      // When we exclude the 3h session, only 1h is counted, so 1+2=3 ≤ 4
+      await expect(
+        service.validateDailyHoursLimit(
+          'tutor-1',
+          '2025-04-07',
+          2,
+          'session-to-exclude',
+        ),
+      ).resolves.toBeUndefined();
+
+      // Verify andWhere was called to exclude the session
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'session.idSession != :excludeSessionId',
+        { excludeSessionId: 'session-to-exclude' },
+      );
+    });
+  });
+
   // ─── validateCancellationTime ─────────────────────────────────────────────────
 
   describe('validateCancellationTime', () => {

--- a/src/modules/scheduling/services/session-validation.service.ts
+++ b/src/modules/scheduling/services/session-validation.service.ts
@@ -220,6 +220,56 @@ export class SessionValidationService {
   }
 
   // ─────────────────────────────────────────────────────────────────────────
+  // HU-19.1.4 — Límite diario del tutor
+  //
+  // Valida que las horas AGENDADAS en un día específico no excedan el límite
+  // diario (máximo 4 horas). Solo cuenta sesiones SCHEDULED + PENDING_MODIFICATION
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async validateDailyHoursLimit(
+    tutorId: string,
+    scheduledDate: string, // 'YYYY-MM-DD'
+    durationHours: number,
+    excludeSessionId?: string,
+  ): Promise<void> {
+    const qb = this.sessionRepository
+      .createQueryBuilder('session')
+      .where('session.idTutor = :tutorId', { tutorId })
+      .andWhere('DATE(session.scheduledDate) = :scheduledDate', {
+        scheduledDate,
+      })
+      .andWhere('session.status IN (:...activeStatuses)', {
+        activeStatuses: [
+          SessionStatus.SCHEDULED,
+          SessionStatus.PENDING_MODIFICATION,
+        ],
+      });
+
+    if (excludeSessionId) {
+      qb.andWhere('session.idSession != :excludeSessionId', {
+        excludeSessionId,
+      });
+    }
+
+    const sessions = await qb.getMany();
+
+    const hoursThisDay = sessions.reduce(
+      (sum, s) => sum + this.calcDurationFromTimes(s.startTime, s.endTime),
+      0,
+    );
+
+    const DAILY_HOURS_LIMIT = 4; // Máximo 4 horas por día
+
+    if (hoursThisDay + durationHours > DAILY_HOURS_LIMIT) {
+      throw new BadRequestException(
+        `El tutor ha alcanzado su límite diario de ${DAILY_HOURS_LIMIT}h ` +
+          `(${hoursThisDay}h usadas + ${durationHours}h solicitadas = ` +
+          `${hoursThisDay + durationHours}h).`,
+      );
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
   // HU-19.1.4 — Límite semanal del tutor
   //
   // Usamos parseISO (date-fns) para construir el Date de referencia desde

--- a/src/modules/scheduling/services/session.service.spec.ts
+++ b/src/modules/scheduling/services/session.service.spec.ts
@@ -706,6 +706,7 @@ describe('SessionService', () => {
       managerMock.createQueryBuilder
         .mockReturnValueOnce(makeQb('getOne', session)) // get session
         .mockReturnValueOnce(makeQb('getOne', null)) // no conflicting
+        .mockReturnValueOnce(makeQb('getMany', [])) // daySessions (daily hours check)
         .mockReturnValueOnce(makeQb('getMany', [])); // no other pending
       managerMock.findOne
         .mockResolvedValueOnce({
@@ -751,6 +752,7 @@ describe('SessionService', () => {
       managerMock.createQueryBuilder
         .mockReturnValueOnce(makeQb('getOne', session)) // get session
         .mockReturnValueOnce(makeQb('getOne', null)) // no conflicting
+        .mockReturnValueOnce(makeQb('getMany', [])) // daySessions (daily hours check)
         .mockReturnValueOnce(makeQb('getMany', [competitor1, competitor2])); // 2 competing
 
       managerMock.findOne
@@ -793,8 +795,9 @@ describe('SessionService', () => {
     };
 
     const setupHappyPath = () => {
-      // No confirmed session in slot, 0 pending
+      // Daily hours check, no confirmed session in slot, 0 pending
       managerMock.createQueryBuilder
+        .mockReturnValueOnce(makeQb('getRawOne', { totalHours: '0' })) // daily hours
         .mockReturnValueOnce(makeQb('getOne', null)) // confirmedInSlot
         .mockReturnValueOnce(makeQb('getCount', 0)); // pendingCount
 
@@ -824,9 +827,9 @@ describe('SessionService', () => {
     });
 
     it('throws BadRequestException when slot is already confirmed (pessimistic lock)', async () => {
-      managerMock.createQueryBuilder.mockReturnValueOnce(
-        makeQb('getOne', { idSession: 'other-session' }),
-      ); // confirmedInSlot
+      managerMock.createQueryBuilder
+        .mockReturnValueOnce(makeQb('getRawOne', { totalHours: '0' })) // daily hours
+        .mockReturnValueOnce(makeQb('getOne', { idSession: 'other-session' })); // confirmedInSlot
 
       await expect(
         service.createIndividualSession('student-1', dto),
@@ -836,6 +839,7 @@ describe('SessionService', () => {
 
     it('throws BadRequestException on DB unique constraint violation (code 23505)', async () => {
       managerMock.createQueryBuilder
+        .mockReturnValueOnce(makeQb('getRawOne', { totalHours: '0' })) // daily hours
         .mockReturnValueOnce(makeQb('getOne', null)) // no confirmed
         .mockReturnValueOnce(makeQb('getCount', 0)); // pendingCount
 
@@ -864,6 +868,7 @@ describe('SessionService', () => {
 
     it('includes pending request count in message when slot already has pending requests', async () => {
       managerMock.createQueryBuilder
+        .mockReturnValueOnce(makeQb('getRawOne', { totalHours: '0' })) // daily hours
         .mockReturnValueOnce(makeQb('getOne', null)) // no confirmed
         .mockReturnValueOnce(makeQb('getCount', 2)); // 2 other pending
 

--- a/src/modules/scheduling/services/session.service.spec.ts
+++ b/src/modules/scheduling/services/session.service.spec.ts
@@ -716,13 +716,14 @@ describe('SessionService', () => {
 
       // Post-transaction mock setup
       sessionRepository.findOne.mockResolvedValue(mockSession());
-      managerMock.save.mockResolvedValue({ ...session, status: SessionStatus.SCHEDULED });
+      managerMock.save.mockResolvedValue({
+        ...session,
+        status: SessionStatus.SCHEDULED,
+      });
 
       const result = await service.confirmSession('tutor-1', 'session-1', {});
 
-      expect(session.status).toBe(
-        SessionStatus.SCHEDULED,
-      );
+      expect(session.status).toBe(SessionStatus.SCHEDULED);
       expect(session.tutorConfirmed).toBe(true);
       expect(result.autoRejectedCount).toBe(0);
       expect(queryRunnerMock.commitTransaction).toHaveBeenCalled();

--- a/src/modules/scheduling/services/session.service.spec.ts
+++ b/src/modules/scheduling/services/session.service.spec.ts
@@ -11,7 +11,13 @@ import { ParticipationStatus } from '../enums/participation-status.enum';
 // ─── QueryBuilder factory ─────────────────────────────────────────────────────
 // Returns a chainable QB mock; terminalFn is the method that resolves with value.
 const makeQb = (
-  terminalFn: 'getOne' | 'getMany' | 'getCount' | 'getManyAndCount' | 'getRawOne' | 'getRawMany',
+  terminalFn:
+    | 'getOne'
+    | 'getMany'
+    | 'getCount'
+    | 'getManyAndCount'
+    | 'getRawOne'
+    | 'getRawMany',
   value: any,
 ) => {
   const qb: any = {

--- a/src/modules/scheduling/services/session.service.spec.ts
+++ b/src/modules/scheduling/services/session.service.spec.ts
@@ -138,6 +138,7 @@ describe('SessionService', () => {
         .mockResolvedValue(undefined),
       validateNoTimeConflict: jest.fn().mockResolvedValue(undefined),
       validateWeeklyHoursLimit: jest.fn().mockResolvedValue(undefined),
+      validateDailyHoursLimit: jest.fn().mockResolvedValue(undefined),
       validateCancellationTime: jest.fn().mockReturnValue(true),
       calculateEndTime: jest.fn().mockReturnValue('10:00'),
     };

--- a/src/modules/scheduling/services/session.service.spec.ts
+++ b/src/modules/scheduling/services/session.service.spec.ts
@@ -11,7 +11,7 @@ import { ParticipationStatus } from '../enums/participation-status.enum';
 // ─── QueryBuilder factory ─────────────────────────────────────────────────────
 // Returns a chainable QB mock; terminalFn is the method that resolves with value.
 const makeQb = (
-  terminalFn: 'getOne' | 'getMany' | 'getCount' | 'getManyAndCount',
+  terminalFn: 'getOne' | 'getMany' | 'getCount' | 'getManyAndCount' | 'getRawOne' | 'getRawMany',
   value: any,
 ) => {
   const qb: any = {
@@ -30,6 +30,8 @@ const makeQb = (
     getMany: jest.fn().mockResolvedValue([]),
     getCount: jest.fn().mockResolvedValue(0),
     getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    getRawOne: jest.fn().mockResolvedValue(null),
+    getRawMany: jest.fn().mockResolvedValue([]),
   };
   qb[terminalFn].mockResolvedValue(value);
   return qb;

--- a/src/modules/scheduling/services/session.service.spec.ts
+++ b/src/modules/scheduling/services/session.service.spec.ts
@@ -720,7 +720,9 @@ describe('SessionService', () => {
 
       const result = await service.confirmSession('tutor-1', 'session-1', {});
 
-      expect(session.status).toBe(SessionStatus.SCHEDULED);
+      expect(session.status).toBe(
+        SessionStatus.SCHEDULED,
+      );
       expect(session.tutorConfirmed).toBe(true);
       expect(result.autoRejectedCount).toBe(0);
       expect(queryRunnerMock.commitTransaction).toHaveBeenCalled();

--- a/src/modules/scheduling/services/session.service.spec.ts
+++ b/src/modules/scheduling/services/session.service.spec.ts
@@ -714,8 +714,9 @@ describe('SessionService', () => {
         }) // scheduledSession
         .mockResolvedValueOnce({ idStudent: 'student-1' }); // confirmedParticipation
 
-      // getSessionById call after commit needs sessionRepository
+      // Post-transaction mock setup
       sessionRepository.findOne.mockResolvedValue(mockSession());
+      managerMock.save.mockResolvedValue({ ...session, status: SessionStatus.SCHEDULED });
 
       const result = await service.confirmSession('tutor-1', 'session-1', {});
 

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -359,16 +359,19 @@ export class SessionService {
         .orderBy('ss.idSession', 'ASC')
         .setLock('pessimistic_write')
         .getMany();
-      const alreadyScheduledMinutes = daySessions.reduce((total, dayScheduled) => {
-        if (
-          dayScheduled.idSession === sessionId ||
-          !dayScheduled.session ||
-          dayScheduled.session.status !== SessionStatus.SCHEDULED
-        ) {
-          return total;
-        }
-        return total + this.calcDuration(dayScheduled.session);
-      }, 0);
+      const alreadyScheduledMinutes = daySessions.reduce(
+        (total, dayScheduled) => {
+          if (
+            dayScheduled.idSession === sessionId ||
+            !dayScheduled.session ||
+            dayScheduled.session.status !== SessionStatus.SCHEDULED
+          ) {
+            return total;
+          }
+          return total + this.calcDuration(dayScheduled.session);
+        },
+        0,
+      );
       const maxDailyMinutes = 4 * 60;
       if (alreadyScheduledMinutes + sessionDuration > maxDailyMinutes) {
         throw new BadRequestException(

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -135,6 +135,13 @@ export class SessionService {
         dto.durationHours,
       );
 
+      // No supera el límite diario del tutor (máximo 4 horas por día)
+      await this.validationService.validateDailyHoursLimit(
+        dto.tutorId,
+        dto.scheduledDate,
+        dto.durationHours,
+      );
+
       // ── 2. Verificación de concurrencia con lock pesimista ────────────────
       //
       // Aquí solo bloqueamos si hay OTRA sesión CONFIRMADA (SCHEDULED) en el
@@ -664,6 +671,16 @@ export class SessionService {
         newDuration,
         session.idSession,
       );
+
+      // ========================================
+      // VALIDACIÓN DE LÍMITE DIARIO
+      // ========================================
+      await this.validationService.validateDailyHoursLimit(
+        session.idTutor,
+        newDate,
+        newDuration,
+        session.idSession,
+      );
     }
 
     // ========================================
@@ -834,6 +851,14 @@ export class SessionService {
         session.idTutor,
         newDate,
         newStartTime,
+        newDuration,
+        session.idSession,
+      );
+
+      // Re-validar límite diario antes de aceptar la modificación
+      await this.validationService.validateDailyHoursLimit(
+        session.idTutor,
+        newDate,
         newDuration,
         session.idSession,
       );

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -135,12 +135,32 @@ export class SessionService {
         dto.durationHours,
       );
 
-      // No supera el límite diario del tutor (máximo 4 horas por día)
-      await this.validationService.validateDailyHoursLimit(
-        dto.tutorId,
-        dto.scheduledDate,
-        dto.durationHours,
-      );
+      // No supera el límite diario del tutor (máximo 4 horas por día).
+      // Esta validación debe correr dentro de la misma transacción y tomando
+      // lock sobre las sesiones del tutor en la fecha para evitar carreras
+      // entre requests concurrentes en slots distintos del mismo día.
+      const dailyHoursRaw = await queryRunner.manager
+        .createQueryBuilder(ScheduledSession, 'ss')
+        .innerJoin('ss.session', 'session')
+        .select('COALESCE(SUM(session.durationHours), 0)', 'totalHours')
+        .where('ss.idTutor = :tutorId', { tutorId: dto.tutorId })
+        .andWhere('ss.scheduledDate = :scheduledDate', {
+          scheduledDate: new Date(dto.scheduledDate),
+        })
+        .andWhere('session.status IN (:...statuses)', {
+          statuses: [
+            SessionStatus.SCHEDULED,
+            SessionStatus.PENDING_MODIFICATION,
+          ],
+        })
+        .setLock('pessimistic_write')
+        .getRawOne<{ totalHours: string }>();
+      const existingDailyHours = Number(dailyHoursRaw?.totalHours ?? 0);
+      if (existingDailyHours + dto.durationHours > 4) {
+        throw new BadRequestException(
+          'El tutor no puede superar 4 horas de sesiones en un mismo día.',
+        );
+      }
 
       // ── 2. Verificación de concurrencia con lock pesimista ────────────────
       //

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -344,14 +344,37 @@ export class SessionService {
         );
       }
 
-      // Validar que la confirmación no cause que se exceda el límite diario
+      // Validar que la confirmación no cause que se exceda el límite diario.
+      // Esta validación debe hacerse dentro de la misma transacción y con lock
+      // sobre las sesiones del tutor en el día para evitar carreras entre
+      // confirmaciones concurrentes de distintas franjas del mismo día.
       const sessionDuration = this.calcDuration(session);
-      await this.validationService.validateDailyHoursLimit(
-        tutorId,
-        session.scheduledDate,
-        sessionDuration,
-        sessionId, // excluir esta sesión de la cuenta
-      );
+      const daySessions = await queryRunner.manager
+        .createQueryBuilder(ScheduledSession, 'ss')
+        .innerJoinAndSelect('ss.session', 'daySession')
+        .where('ss.idTutor = :tutorId', { tutorId })
+        .andWhere('ss.scheduledDate = :scheduledDate', {
+          scheduledDate: scheduledSession.scheduledDate,
+        })
+        .orderBy('ss.idSession', 'ASC')
+        .setLock('pessimistic_write')
+        .getMany();
+      const alreadyScheduledMinutes = daySessions.reduce((total, dayScheduled) => {
+        if (
+          dayScheduled.idSession === sessionId ||
+          !dayScheduled.session ||
+          dayScheduled.session.status !== SessionStatus.SCHEDULED
+        ) {
+          return total;
+        }
+        return total + this.calcDuration(dayScheduled.session);
+      }, 0);
+      const maxDailyMinutes = 4 * 60;
+      if (alreadyScheduledMinutes + sessionDuration > maxDailyMinutes) {
+        throw new BadRequestException(
+          'La confirmación excede el límite diario de 4 horas para el tutor.',
+        );
+      }
 
       // Confirmar
       session.status = SessionStatus.SCHEDULED;

--- a/src/modules/scheduling/services/session.service.ts
+++ b/src/modules/scheduling/services/session.service.ts
@@ -324,6 +324,15 @@ export class SessionService {
         );
       }
 
+      // Validar que la confirmación no cause que se exceda el límite diario
+      const sessionDuration = this.calcDuration(session);
+      await this.validationService.validateDailyHoursLimit(
+        tutorId,
+        session.scheduledDate,
+        sessionDuration,
+        sessionId, // excluir esta sesión de la cuenta
+      );
+
       // Confirmar
       session.status = SessionStatus.SCHEDULED;
       session.tutorConfirmed = true;

--- a/src/modules/tutor/services/tutor.service.ts
+++ b/src/modules/tutor/services/tutor.service.ts
@@ -506,6 +506,24 @@ export class TutorService {
     return tutor.limitDisponibility ?? 8;
   }
 
+  /**
+   * Obtener el límite diario de horas de un tutor (máximo de horas agendables por día)
+   * Actualmente es una constante de 4 horas para todos los tutores
+   */
+  async getDailyHoursLimit(tutorId: string): Promise<number> {
+    // Verificar que el tutor existe
+    const tutor = await this.tutorRepository.findOne({
+      where: { idUser: tutorId },
+    });
+
+    if (!tutor) {
+      throw new NotFoundException('Tutor not found');
+    }
+
+    // Retornar constante de 4 horas por día
+    return 4;
+  }
+
   async updateWeeklyHoursLimit(tutorId: string, maxWeeklyHours: number) {
     const MAX_DECLARABLE_WEEKLY_HOURS = 8;
 


### PR DESCRIPTION
# Descripción
Se añaden algunos test unitarios faltantes a availability service. Se corrige el error de validacion de la regla de negocio de máximo 4 horas agendables por día, en lugar de como se estaba haciendo (restringir slots de disponibilidad a 8, algo erróneo pues un tutor puede tener muchas más disponibilidades, siempre y cuando sólo se agenden máximo 4 horas por día y no se exceda el limite semanal).

## Tipo de cambio
- [X] Bug fix (arreglo de error)
- [ ] Nueva funcionalidad
- [ ] Cambio breaking (cambio que requiere ajustes en otras partes)
- [ ] Mejora de rendimiento
- [ ] Refactorización (sin cambios funcionales)
- [ ] Documentación

## ¿Cómo se probó?
- [ ] Tests unitarios
- [ ] Tests de integración
- [X] Pruebas manuales

## Checklist
- [X] Mi código sigue las guías de estilo del proyecto
- [X] Actualicé la documentación correspondiente
- [X] Los tests pasan localmente
- [X] No hay conflictos con la rama principal

