### PR TITLE
fix/availability-empty-slots

### DIFF
--- a/src/modules/availability/services/availability.service.spec.ts
+++ b/src/modules/availability/services/availability.service.spec.ts
@@ -663,17 +663,26 @@ describe('AvailabilityService', () => {
       expect(result.availableSlots).toHaveLength(2);
     });
 
-    it('throws NotFoundException if tutor has no availability configured', async () => {
+    it('returns empty slots when tutor has no availability configured', async () => {
       // Ensure mocks are properly reset and set up for this test
       tutorHaveAvailabilityRepository.find.mockResolvedValue([]);
+      tutorHaveAvailabilityRepository.findOne.mockResolvedValue(null);
       // Also ensure scheduledSessionRepository is mocked if getTutorAvailability uses it
       const qb = createQueryBuilderMock();
       qb.getMany.mockResolvedValue([]);
       scheduledSessionRepository.createQueryBuilder.mockReturnValue(qb);
 
-      await expect(
-        service.getTutorAvailability('tutor-1'),
-      ).rejects.toBeInstanceOf(NotFoundException);
+      const result = await service.getTutorAvailability('tutor-1');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          tutorId: 'tutor-1',
+          tutorName: 'Tutor',
+          totalSlots: 0,
+          availableSlots: [],
+          groupedByDay: {},
+        }),
+      );
     });
   });
 

--- a/src/modules/availability/services/availability.service.ts
+++ b/src/modules/availability/services/availability.service.ts
@@ -423,8 +423,14 @@ export class AvailabilityService {
       },
     );
 
-    if (tutorAvailabilities.length === 0) {
-      throw new NotFoundException('Tutor no tiene disponibilidad configurada');
+    // Obtener nombre del tutor
+    let tutorName: string;
+    if (tutorAvailabilities.length > 0) {
+      tutorName = tutorAvailabilities[0].tutor.user.name;
+    } else {
+      // Si no hay slots, usa un nombre por defecto
+      // (no hay forma de obtener el nombre si no existe ningún registro de disponibilidad)
+      tutorName = 'Tutor';
     }
 
     // Obtener sesiones activas del tutor con su duración real
@@ -467,7 +473,7 @@ export class AvailabilityService {
 
     return {
       tutorId,
-      tutorName: tutorAvailabilities[0].tutor.user.name,
+      tutorName,
       weekReference: weekStartStr,
       totalSlots: slots.length,
       availableSlots: slots.filter((s) => s.isAvailable),


### PR DESCRIPTION
# Descripción
Mod: Se modifica el método getTutorAvailability en AvailabilityService para que, en caso de no tener disponibilidades configuradas, devolver una lista vacía y el resto de información, en lugar de lanzar una excepción.

## Tipo de cambio
- [X] Bug fix (arreglo de error)
- [ ] Nueva funcionalidad
- [ ] Cambio breaking (cambio que requiere ajustes en otras partes)
- [ ] Mejora de rendimiento
- [ ] Refactorización (sin cambios funcionales)
- [ ] Documentación

## ¿Cómo se probó?
- [ ] Tests unitarios
- [ ] Tests de integración
- [X] Pruebas manuales

## Checklist
- [X] Mi código sigue las guías de estilo del proyecto
- [X] Actualicé la documentación correspondiente
- [X] Los tests pasan localmente
- [X] No hay conflictos con la rama principal

