### PR TITLE
fix(evaluation): corregir join en getTutorEvaluations

### DIFF
--- a/src/modules/session-execution/services/evaluation.service.ts
+++ b/src/modules/session-execution/services/evaluation.service.ts
@@ -450,14 +450,14 @@ export class EvaluationService {
       }
     }
 
-    // Construir query base para obtener answers de sesiones del tutor
+    // Construir query base para obtener answers de sesiones del tutor.
+    // Answer no tiene relación @ManyToOne con Session, por lo que se hace
+    // un innerJoin directo contra la entidad Session usando la FK id_session.
     const answerQuery = this.answerRepository
       .createQueryBuilder('answer')
       .leftJoinAndSelect('answer.question', 'question')
-      .leftJoinAndSelect('answer.session', 'session')
-      .leftJoinAndSelect('session.tutor', 'tutor')
-      .leftJoinAndSelect('session.subject', 'subject')
       .leftJoinAndSelect('answer.studentParticipateSession', 'participation')
+      .innerJoin(Session, 'session', 'session.id_session = answer.id_session')
       .where('session.id_tutor = :tutorId', { tutorId })
       .andWhere('session.status = :status', {
         status: SessionStatus.COMPLETED,


### PR DESCRIPTION
Answer no tiene relación @ManyToOne con Session, por lo que leftJoinAndSelect('answer.session', ...) lanzaba un error de TypeORM al no encontrar la relación. Se reemplaza con innerJoin directo contra la entidad Session usando la FK id_session.

_Para las preguntas que requieren de respuesta, añadirla en la descripción de la PR. Por ejemplo, "¿Qué cambia?", "Describe brevemente los casos probados", etc._

## Contexto
<!-- Link al issue y/o spec con criterios de aceptación. Si no existe spec, este PR no debería abrirse todavía. -->
Issue/Spec: #___

## ¿Qué cambia?
<!-- Descripción breve y técnica. Qué dominio/módulo toca (ej. scheduling, auth, notifications). -->

## ¿Por qué? (si aplica)
<!-- Solo si esto involucra una decisión de negocio o técnica no obvia. Si la decisión es relevante a futuro, agregar un ADR corto en /docs/adr y enlazarlo aquí. -->
ADR relacionado: (enlace o "N/A")

## Cambios en base de datos
- [ ] Este PR incluye migraciones
- [ ] Las migraciones fueron probadas localmente (up y down)
- [ ] N/A

## Pruebas realizadas
- [ ] Camino feliz probado
- [ ] Al menos un caso borde probado (ej. datos inválidos, concurrencia, permisos incorrectos, límites como "0 franjas disponibles")
- [ ] Pruebas automatizadas agregadas/actualizadas (si el estándar del equipo lo requiere para este tipo de lógica)

Describe brevemente los casos probados:
-

## Contrato de API (si aplica)
- [ ] La documentación de la API (endpoint, request/response, códigos de error) fue actualizada
- [ ] Los tipos/interfaces compartidos con frontend fueron actualizados
- [ ] N/A

## Checklist de estándares
- [ ] Sigue la separación de responsabilidades por dominio/módulo ya definida
- [ ] Manejo de errores centralizado (no try/catch sueltos sin propósito)
- [ ] No hay código muerto, `console.log`/`print` de debug, ni comentarios de "TODO" sin issue asociado
- [ ] Se revisó si ya existía una función/utilidad reutilizable antes de crear una nueva

## ¿Esto coincide con la spec original?
- [ ] Sí, se verificó explícitamente contra los criterios de aceptación del issue
- [ ] Hubo cambios respecto a la spec original → se actualizó el documento/issue correspondiente

## Reviewer
- [ ] Persona distinta a quien implementó revisó este PR
